### PR TITLE
Make language tags use case-insensitive comparison and hashing

### DIFF
--- a/sophia/src/term/_literal_kind.rs
+++ b/sophia/src/term/_literal_kind.rs
@@ -52,8 +52,8 @@ where
 {
     fn hash<H: Hasher>(&self, state: &mut H) {
         match self {
-            Lang(tag) => tag.as_ref().hash(state),
             Datatype(iri) => iri.hash(state),
+            Lang(tag) => tag.as_ref().to_lowercase().hash(state),
         }
     }
 }
@@ -65,7 +65,7 @@ where
 {
     fn eq(&self, other: &LiteralKind<U>) -> bool {
         match (self, other) {
-            (Lang(tag1), Lang(tag2)) => tag1.as_ref() == tag2.as_ref(),
+            (Lang(tag1), Lang(tag2)) => tag1.as_ref().eq_ignore_ascii_case(tag2.as_ref()),
             (Datatype(iri1), Datatype(iri2)) => iri1 == iri2,
             _ => false,
         }


### PR DESCRIPTION
Hi!

While toying with the library, I noticed that the comparison of language tags was case-sensitive. According to the [RDF Concepts and Abstract Syntax](https://www.w3.org/TR/rdf11-concepts/), language tags are defined in [BCP47](https://tools.ietf.org/html/bcp47), which states:
> All comparisons MUST be performed in a case-insensitive manner.

This can be found in the W3C RDF/XML syntax examples: [`example08.rdf`](https://www.w3.org/TR/2004/REC-rdf-syntax-grammar-20040210/example08.rdf) has `en-US`  while [`example08.nt`](https://www.w3.org/TR/2004/REC-rdf-syntax-grammar-20040210/example08.nt) has `en-us` where both are supposed to be equal.

This PR fixes `PartialEq`, but also `Hash`, to make comparison and hashing of `LiteralKind` case-insensitive. (*About the `to_lowercase` call: this one allocates, while it could be possible to loop over all characters of the `tag1` and hash their lowercase variant without allocating, but since language tags are extremely small strings I am not sure this would really be an improvement over allocating and hashing the buffered bytes directly).