### PR TITLE
Fix XML parser and bump URL dependency 

### DIFF
--- a/sophia/Cargo.toml
+++ b/sophia/Cargo.toml
@@ -8,8 +8,10 @@ documentation = "https://docs.rs/sophia"
 readme = "../README.md"
 license = "CECILL-C"
 keywords = ["rdf", "linked-data", "semantic-web"]
-
 edition = "2018"
+
+[package.metadata.docs.rs]
+all-features = true
 
 [features]
 default = []

--- a/sophia/Cargo.toml
+++ b/sophia/Cargo.toml
@@ -15,7 +15,7 @@ all-features = true
 
 [features]
 default = []
-xml = ["quick-xml"]
+xml = ["quick-xml", "percent-encoding"]
 
 [dependencies]
 coercible_errors = "0.1.4"
@@ -27,7 +27,8 @@ pest_derive = "2.1.0"
 regex = "1.1.7"
 rental = "0.5.4"
 resiter = "0.3.0"
-url = "1.7.2"
+url = "2.1.0"
 weak-table = "0.2.3"
 
 quick-xml = { version = "0.14.0", optional = true }
+percent-encoding = { version = "2.1.0", optional = true }

--- a/sophia/src/parser/xml.rs
+++ b/sophia/src/parser/xml.rs
@@ -491,7 +491,7 @@ impl<F: TermFactory> Scope<F> {
             let ascii = iri.chars().all(|c| c.is_ascii());
 
             fn decode(s: &str) -> std::borrow::Cow<str> {
-                url::percent_encoding::percent_decode(s.as_bytes())
+                percent_encoding::percent_decode(s.as_bytes())
                     .decode_utf8()
                     .expect("always OK since validated with `is_relative_iri`")
             }


### PR DESCRIPTION
This PR fixes #12 by adding `percent-encoding` as a direct dependency, and updates the `url` crate to version `2.1.0`. I also added a field to `Cargo.toml` so that the documentation is built with all features enabled on `docs.rs`, so that the XML parser doc is built as well.

By the way, @phillord and I would be glad to have the XML parser released in a new version (`0.3.0` I suppose) whenever you can push that.