### PR TITLE
changed in error handling and iterator semantics

### DIFF
--- a/sophia/Cargo.toml
+++ b/sophia/Cargo.toml
@@ -19,8 +19,6 @@ rio = ["rio_api", "rio_turtle"]
 xml = ["quick-xml", "percent-encoding"]
 
 [dependencies]
-coercible_errors = "0.1.4"
-error-chain = "0.12.1"
 language-tag = "0.9.0"
 lazy_static = "1.3.0"
 pest = "2.1.1"
@@ -36,3 +34,5 @@ percent-encoding = { version = "2.1.0", optional = true }
 
 rio_api = { version = "0.2.0", optional = true }
 rio_turtle = { version = "0.2.0", optional = true }
+thiserror = "1.0.9"
+anyhow = "1.0.25"

--- a/sophia/src/dataset.rs
+++ b/sophia/src/dataset.rs
@@ -22,3 +22,6 @@ mod _sinks;
 pub use self::_sinks::*;
 mod _traits;
 pub use self::_traits::*;
+
+mod _error;
+pub use self::_error::*;

--- a/sophia/src/dataset/_error.rs
+++ b/sophia/src/dataset/_error.rs
@@ -1,0 +1,30 @@
+use thiserror::Error;
+use crate::error::Infallible;
+
+pub type DatasetResult<T> = Result<T, DatasetError>;
+
+#[derive(Debug, Error)]
+pub enum DatasetError {
+	#[error("Custom: {msg}")]
+	Custom { msg: String },
+	#[error("MutationFailed: {msg}")]
+	CustomMuatation { msg: String },
+	#[error("UnsopportedGraphName: {name}")]
+	UnsupportedGraphName{ name: String },
+	#[error("FromInnerGraph: {source}")]
+	FromGraph { #[from] source: crate::graph::GraphError },
+}
+
+impl From<String> for DatasetError {
+	fn from(msg: String) -> Self {
+		Self::Custom { msg }
+	}
+}
+
+impl From<Infallible> for DatasetError {
+	/// This implementation is only for support of the type system.
+	/// As `Infallible` can not be instantiatet this will never execute.
+	fn from(_: Infallible) -> Self {
+		unreachable!()
+	}
+}

--- a/sophia/src/dataset/_ext_impl.rs
+++ b/sophia/src/dataset/_ext_impl.rs
@@ -3,11 +3,11 @@
 
 use std::collections::HashSet;
 use std::hash::Hash;
+use crate::error::*;
 
 use resiter::oks::*;
 
 use super::*;
-use crate::error::*;
 use crate::quad::stream::AsQuadSource;
 use crate::quad::*;
 use crate::term::*;
@@ -18,7 +18,7 @@ where
     Q: Quad<'a> + 'a,
 {
     type Quad = &'a Q;
-    type Error = Never;
+    type Error = Infallible;
 
     #[inline]
     fn quads(&'a self) -> DQuadSource<Self> {
@@ -31,7 +31,7 @@ where
     Q: Quad<'a> + 'a,
 {
     type Quad = &'a Q;
-    type Error = Never;
+    type Error = Infallible;
 
     #[inline]
     fn quads(&'a self) -> DQuadSource<Self> {
@@ -40,7 +40,7 @@ where
 }
 
 impl MutableDataset for Vec<([BoxTerm; 3], Option<BoxTerm>)> where {
-    type MutationError = Never;
+    type MutationError = Infallible;
 
     fn insert<T, U, V, W>(
         &mut self,
@@ -48,7 +48,7 @@ impl MutableDataset for Vec<([BoxTerm; 3], Option<BoxTerm>)> where {
         p: &Term<U>,
         o: &Term<V>,
         g: Option<&Term<W>>,
-    ) -> MDResult<Self, bool>
+    ) -> Result<bool, Self::MutationError>
     where
         T: TermData,
         U: TermData,
@@ -68,7 +68,7 @@ impl MutableDataset for Vec<([BoxTerm; 3], Option<BoxTerm>)> where {
         p: &Term<U>,
         o: &Term<V>,
         g: Option<&Term<W>>,
-    ) -> MDResult<Self, bool>
+    ) -> Result<bool, Self::MutationError>
     where
         T: TermData,
         U: TermData,
@@ -93,7 +93,7 @@ where
     Q: Eq + Hash + Quad<'a> + 'a,
 {
     type Quad = &'a Q;
-    type Error = Never;
+    type Error = Infallible;
 
     #[inline]
     fn quads(&'a self) -> DQuadSource<Self> {
@@ -102,7 +102,7 @@ where
 }
 
 impl<S: ::std::hash::BuildHasher> MutableDataset for HashSet<([BoxTerm; 3], Option<BoxTerm>), S> {
-    type MutationError = Never;
+    type MutationError = Infallible;
 
     fn insert<T, U, V, W>(
         &mut self,
@@ -110,7 +110,7 @@ impl<S: ::std::hash::BuildHasher> MutableDataset for HashSet<([BoxTerm; 3], Opti
         p: &Term<U>,
         o: &Term<V>,
         g: Option<&Term<W>>,
-    ) -> MDResult<Self, bool>
+    ) -> Result<bool, Self::MutationError>
     where
         T: TermData,
         U: TermData,
@@ -129,7 +129,7 @@ impl<S: ::std::hash::BuildHasher> MutableDataset for HashSet<([BoxTerm; 3], Opti
         p: &Term<U>,
         o: &Term<V>,
         g: Option<&Term<W>>,
-    ) -> MDResult<Self, bool>
+    ) -> Result<bool, Self::MutationError>
     where
         T: TermData,
         U: TermData,

--- a/sophia/src/dataset/adapter.rs
+++ b/sophia/src/dataset/adapter.rs
@@ -133,7 +133,7 @@ where
 {
     type MutationError = D::MutationError;
 
-    fn insert<T, U, V>(&mut self, s: &Term<T>, p: &Term<U>, o: &Term<V>) -> MGResult<Self, bool>
+    fn insert<T, U, V>(&mut self, s: &Term<T>, p: &Term<U>, o: &Term<V>) -> Result<bool, Self::MutationError>
     where
         T: TermData,
         U: TermData,
@@ -144,7 +144,7 @@ where
             .insert(s, p, o, self.gmatcher.as_ref())
     }
 
-    fn remove<T, U, V>(&mut self, s: &Term<T>, p: &Term<U>, o: &Term<V>) -> MGResult<Self, bool>
+    fn remove<T, U, V>(&mut self, s: &Term<T>, p: &Term<U>, o: &Term<V>) -> Result<bool, Self::MutationError>
     where
         T: TermData,
         U: TermData,
@@ -173,9 +173,9 @@ pub(crate) mod test {
     use super::*;
     use crate::dataset::inmem::LightDataset;
     use crate::dataset::test::*;
-    use crate::dataset::MDResult;
     use crate::ns::rdfs;
     use crate::term::BoxTerm;
+    use anyhow::Result;
 
     pub type LightDatasetGraph = DatasetGraph<LightDataset, LightDataset, Option<BoxTerm>>;
 
@@ -199,7 +199,7 @@ pub(crate) mod test {
     // because I couldn't call it from this module...
 
     #[test]
-    fn test_graph_default() -> MDResult<LightDataset, ()> {
+    fn test_graph_default() -> Result<()> {
         let mut d = LightDataset::new();
         populate(&mut d)?;
         assert_eq!(d.graph(*DG).triples().count(), 4);

--- a/sophia/src/dataset/indexed.rs
+++ b/sophia/src/dataset/indexed.rs
@@ -89,9 +89,9 @@ macro_rules! impl_mutable_dataset_for_indexed_dataset {
         }
     };
     () => {
-        type MutationError = coercible_errors::Never;
+        type MutationError = $crate::error::Infallible;
 
-        fn insert<T_, U_, V_, W_> (&mut self, s: &Term<T_>, p: &Term<U_>, o: &Term<V_>, g: Option<&Term<W_>>) -> MDResult< Self, bool> where
+        fn insert<T_, U_, V_, W_> (&mut self, s: &Term<T_>, p: &Term<U_>, o: &Term<V_>, g: Option<&Term<W_>>) -> Result<bool, Self::MutationError> where
             T_: $crate::term::TermData,
             U_: $crate::term::TermData,
             V_: $crate::term::TermData,
@@ -99,7 +99,7 @@ macro_rules! impl_mutable_dataset_for_indexed_dataset {
         {
             Ok(self.insert_indexed(s, p, o, g).is_some())
         }
-        fn remove<T_, U_, V_, W_> (&mut self, s: &Term<T_>, p: &Term<U_>, o: &Term<V_>, g: Option<&Term<W_>>) -> MDResult< Self, bool> where
+        fn remove<T_, U_, V_, W_> (&mut self, s: &Term<T_>, p: &Term<U_>, o: &Term<V_>, g: Option<&Term<W_>>) -> Result<bool, Self::MutationError> where
             T_: $crate::term::TermData,
             U_: $crate::term::TermData,
             V_: $crate::term::TermData,

--- a/sophia/src/dataset/inmem/_hash_dataset.rs
+++ b/sophia/src/dataset/inmem/_hash_dataset.rs
@@ -1,10 +1,10 @@
 // this module is transparently re-exported by its parent `dataset::inmem`
 use std::collections::HashSet;
 use std::hash::Hash;
+use crate::error::Infallible;
 
 use crate::dataset::indexed::IndexedDataset;
 use crate::dataset::*;
-use crate::error::*;
 use crate::term::factory::TermFactory;
 use crate::term::index_map::TermIndexMap;
 use crate::term::*;
@@ -166,7 +166,7 @@ where
         [&'a Term<<Self as IndexedDataset>::TermData>; 3],
         Option<&'a Term<<Self as IndexedDataset>::TermData>>,
     );
-    type Error = Never;
+    type Error = Infallible;
 
     fn quads(&'a self) -> DQuadSource<'a, Self> {
         Box::from(self.quads.iter().map(move |[si, pi, oi, gi]| {

--- a/sophia/src/error.rs
+++ b/sophia/src/error.rs
@@ -1,82 +1,31 @@
 //! Types for handling errors.
 
-use pest::error::{InputLocation, LineColLocation};
+// use thiserror::Error;
+//
+// /// This enum is used to identify an infallible operation where the API
+// /// requires to return a `Result`
+// /// 
+// /// Is equal to `std::convert::Infallible`. However, error-handling requires
+// /// `Infallible: From<Infallible>` which is not provided but implemented here.
+// #[derive(Debug, Error)]
+// pub enum Infallible {}
 
-error_chain! {
-    errors {
-        /// Raised by the methods of the [`Graph`](../graph/trait.Graph.html) trait.
-        GraphError(message: String) {
-            display("error while querying Graph: {}", message)
-        }
-        /// Raised by the methods of the [`MutableGraph`](../graph/trait.MutableGraph.html) trait.
-        GraphMutationError(msg: String) {
-            display("error while modifying Graph: {}", msg)
-        }
-        /// Raised whenever a literal is built with an invalid datatype.
-        InvalidDatatype(datatype: String) {
-            display("invalid datatype {}", datatype)
-        }
-        /// Raised whenever an invalid IRI is used as a term.
-        InvalidIri(iri: String) {
-            display("invalid IRI <{}>", iri)
-        }
-        /// Raised whenever a literal is built with an invalid language tag.
-        InvalidLanguageTag(tag: String, message: String) {
-            display("invalid language tag '{}':\n{}", tag, message)
-        }
-        /// Raised whenever a variable is built with an invalid name.
-        InvalidVariableName(name: String) {
-            display("invalid variable name '{}'", name)
-        }
-        /// Raised whenever an invalid prefix is used in a PName.
-        InvalidPrefix(prefix: String) {
-            display("invalid prefix <{}>", prefix)
-        }
-        /// Raised whenever an IRI can not be rendered absolute in a strict RDF graph.
-        IriMustBeAbsolute(iri: String) {
-            display("IRI must be absolute <{}>", iri)
-        }
-        /// Raised by parsers when they encounter a problem.
-        ParserError(message: String, location: InputLocation, line_col: LineColLocation) {
-            display("parse error at {}: {}", display_location(location, line_col), message)
-        }
-        /// Raised by serializers when they encounter a problem.
-        SerializerError(message: String) {
-            display("error while serializing: {}", message)
-        }
-        /// Raised by some mutable dataset
-        UnsupportedGraphName(graph_name: String) {
-            display("unsupported graph_name: {}", graph_name)
-        }
-    }
-}
+// impl From<std::convert::Infallible> for Infallible {
+//     fn from(_: std::convert::Infallible) -> Self {
+//         unreachable!()
+//     }
+// }
 
-fn display_location(il: &InputLocation, lcl: &LineColLocation) -> String {
-    let line = *match lcl {
-        LineColLocation::Pos((line, _)) => line,
-        LineColLocation::Span((line, _), _) => line,
-    };
-    if line == 0 {
-        match il {
-            InputLocation::Pos(pos) => format!("{}", pos),
-            InputLocation::Span((s, e)) => format!("{}-{}", s, e),
-        }
-    } else {
-        match lcl {
-            LineColLocation::Pos((l, c)) => format!("{}:{}", l, c),
-            LineColLocation::Span((l1, c1), (l2, c2)) => format!("{}:{}-{}:{}", l1, c1, l2, c2),
-        }
-    }
-}
+pub type Infallible = std::convert::Infallible;
 
-/// Make a Parser Error with minimal information
-pub fn make_parser_error(message: String, line_offset: usize) -> ErrorKind {
-    let il = InputLocation::Pos(0);
-    let lcl = LineColLocation::Pos((line_offset, 0));
-    ErrorKind::ParserError(message, il, lcl)
-}
 
-coercible_errors!();
+/// Required for convertability to `anyhow::Error`.
+pub trait SafeError: 'static + std::error::Error + Send + Sync {}
+
+impl<E> SafeError for E
+where
+    E: 'static + std::error::Error + Send + Sync
+{}
 
 #[cfg(test)]
 mod test {

--- a/sophia/src/graph.rs
+++ b/sophia/src/graph.rs
@@ -20,3 +20,6 @@ mod _sinks;
 pub use self::_sinks::*;
 mod _traits;
 pub use self::_traits::*;
+
+mod _error;
+pub use self::_error::*;

--- a/sophia/src/graph/_error.rs
+++ b/sophia/src/graph/_error.rs
@@ -1,0 +1,26 @@
+use thiserror::Error;
+use crate::error::Infallible;
+
+pub type GraphResult<T> = Result<T, GraphError>;
+
+#[derive(Debug, Error)]
+pub enum GraphError {
+	#[error("Custom: {msg}")]
+	Custom { msg: String },
+	#[error("MutationFailed: {msg}")]
+	CustomMuatation { msg: String },
+}
+
+impl From<String> for GraphError {
+	fn from(msg: String) -> Self {
+		Self::Custom { msg }
+	}
+}
+
+impl From<Infallible> for GraphError {
+	/// This implementation is only for support of the type system.
+	/// As `Infallible` can not be instantiatet this will never execute.
+	fn from(_: Infallible) -> Self {
+		unreachable!()
+	}
+}

--- a/sophia/src/graph/_ext_impl.rs
+++ b/sophia/src/graph/_ext_impl.rs
@@ -3,11 +3,11 @@
 
 use std::collections::HashSet;
 use std::hash::{BuildHasher, Hash};
+use crate::error::Infallible;
 
 use resiter::oks::*;
 
 use super::*;
-use crate::error::*;
 use crate::term::*;
 use crate::triple::stream::AsTripleSource;
 use crate::triple::*;
@@ -17,7 +17,7 @@ where
     T: Triple<'a> + 'a,
 {
     type Triple = &'a T;
-    type Error = Never;
+    type Error = Infallible;
 
     #[inline]
     fn triples(&'a self) -> GTripleSource<Self> {
@@ -30,7 +30,7 @@ where
     T: Triple<'a> + 'a,
 {
     type Triple = &'a T;
-    type Error = Never;
+    type Error = Infallible;
 
     #[inline]
     fn triples(&'a self) -> GTripleSource<Self> {
@@ -39,9 +39,9 @@ where
 }
 
 impl MutableGraph for Vec<[BoxTerm; 3]> {
-    type MutationError = Never;
+    type MutationError = Infallible;
 
-    fn insert<T, U, V>(&mut self, s: &Term<T>, p: &Term<U>, o: &Term<V>) -> MGResult<Self, bool>
+    fn insert<T, U, V>(&mut self, s: &Term<T>, p: &Term<U>, o: &Term<V>) -> Result<bool, Self::MutationError>
     where
         T: TermData,
         U: TermData,
@@ -53,7 +53,7 @@ impl MutableGraph for Vec<[BoxTerm; 3]> {
         self.push([s, p, o]);
         Ok(true)
     }
-    fn remove<T, U, V>(&mut self, s: &Term<T>, p: &Term<U>, o: &Term<V>) -> MGResult<Self, bool>
+    fn remove<T, U, V>(&mut self, s: &Term<T>, p: &Term<U>, o: &Term<V>) -> Result<bool, Self::MutationError>
     where
         T: TermData,
         U: TermData,
@@ -78,7 +78,7 @@ where
     BH: BuildHasher,
 {
     type Triple = &'a T;
-    type Error = Never;
+    type Error = Infallible;
 
     #[inline]
     fn triples(&'a self) -> GTripleSource<Self> {
@@ -90,9 +90,9 @@ impl<BH> MutableGraph for HashSet<[BoxTerm; 3], BH>
 where
     BH: BuildHasher,
 {
-    type MutationError = Never;
+    type MutationError = Infallible;
 
-    fn insert<T, U, V>(&mut self, s: &Term<T>, p: &Term<U>, o: &Term<V>) -> MGResult<Self, bool>
+    fn insert<T, U, V>(&mut self, s: &Term<T>, p: &Term<U>, o: &Term<V>) -> Result<bool, Self::MutationError>
     where
         T: TermData,
         U: TermData,
@@ -103,7 +103,7 @@ where
         let o = BoxTerm::from(o);
         Ok(HashSet::insert(self, [s, p, o]))
     }
-    fn remove<T, U, V>(&mut self, s: &Term<T>, p: &Term<U>, o: &Term<V>) -> MGResult<Self, bool>
+    fn remove<T, U, V>(&mut self, s: &Term<T>, p: &Term<U>, o: &Term<V>) -> Result<bool, Self::MutationError>
     where
         T: TermData,
         U: TermData,

--- a/sophia/src/graph/indexed.rs
+++ b/sophia/src/graph/indexed.rs
@@ -72,16 +72,16 @@ macro_rules! impl_mutable_graph_for_indexed_graph {
         }
     };
     () => {
-        type MutationError = coercible_errors::Never;
+        type MutationError = $crate::error::Infallible;
 
-        fn insert<T_, U_, V_> (&mut self, s: &Term<T_>, p: &Term<U_>, o: &Term<V_>) -> MGResult< Self, bool> where
+        fn insert<T_, U_, V_> (&mut self, s: &Term<T_>, p: &Term<U_>, o: &Term<V_>) -> Result<bool, Self::MutationError> where
             T_: $crate::term::TermData,
             U_: $crate::term::TermData,
             V_: $crate::term::TermData,
         {
             Ok(self.insert_indexed(s, p, o).is_some())
         }
-        fn remove<T_, U_, V_> (&mut self, s: &Term<T_>, p: &Term<U_>, o: &Term<V_>) -> MGResult< Self, bool> where
+        fn remove<T_, U_, V_> (&mut self, s: &Term<T_>, p: &Term<U_>, o: &Term<V_>) -> Result<bool, Self::MutationError> where
             T_: $crate::term::TermData,
             U_: $crate::term::TermData,
             V_: $crate::term::TermData,

--- a/sophia/src/graph/inmem/_hash_graph.rs
+++ b/sophia/src/graph/inmem/_hash_graph.rs
@@ -2,8 +2,8 @@
 
 use std::collections::HashSet;
 use std::hash::Hash;
+use crate::error::Infallible;
 
-use crate::error::*;
 use crate::graph::indexed::IndexedGraph;
 use crate::graph::*;
 use crate::term::factory::TermFactory;
@@ -136,7 +136,7 @@ where
     <I::Factory as TermFactory>::TermData: 'static,
 {
     type Triple = [&'a Term<<Self as IndexedGraph>::TermData>; 3];
-    type Error = Never;
+    type Error = Infallible;
 
     fn triples(&'a self) -> GTripleSource<'a, Self> {
         Box::from(self.triples.iter().map(move |[si, pi, oi]| {

--- a/sophia/src/lib.rs
+++ b/sophia/src/lib.rs
@@ -44,8 +44,7 @@
 //!
 //!     <http://example.org/bob> <http://xmlns.com/foaf/0.1/name> "Bob" .
 //! "#;
-//! let mut graph = LightGraph::new();
-//! parser::nt::parse_str(example).in_graph(&mut graph);
+//! let mut graph = parser::nt::parse_str(example).collect_to_graph::<LightGraph>().unwrap();
 //!
 //! let ex = Namespace::new("http://example.org/").unwrap();
 //! let foaf = Namespace::new("http://xmlns.com/foaf/0.1/").unwrap();
@@ -63,10 +62,6 @@
 // error_chain is recursing a lot
 #![recursion_limit = "256"]
 
-#[macro_use]
-extern crate coercible_errors;
-#[macro_use]
-extern crate error_chain;
 extern crate language_tag;
 #[macro_use]
 extern crate lazy_static;
@@ -78,7 +73,6 @@ extern crate regex;
 extern crate rental;
 #[cfg(feature = "xml")]
 extern crate quick_xml;
-extern crate resiter;
 #[cfg(feature = "rio")]
 extern crate rio_api;
 #[cfg(feature = "rio")]

--- a/sophia/src/ns.rs
+++ b/sophia/src/ns.rs
@@ -19,8 +19,7 @@
 //! g.insert(&s_name, &rdfs::range, &xsd::string);
 //! ```
 
-use crate::error::*;
-use crate::term::{iri_rfc3987::is_valid_iri, Term, TermData};
+use crate::term::{iri_rfc3987::is_valid_iri, Term, TermData, TermError, TermResult};
 
 /// A custom namespace.
 #[derive(Clone, Debug)]
@@ -30,18 +29,18 @@ impl<T: TermData> Namespace<T> {
     /// Build a custom namespace based on the given IRI.
     ///
     /// `iri` must be a valid IRI, othewise this constructor returns an error.
-    pub fn new(iri: T) -> Result<Namespace<T>> {
+    pub fn new(iri: T) -> TermResult<Namespace<T>> {
         if is_valid_iri(iri.as_ref()) {
             Ok(Namespace(iri))
         } else {
-            Err(ErrorKind::InvalidIri("IRI is invalid".to_string()).into())
+            Err(TermError::InvalidIri { iri: "IRI is invalid".to_string() })
         }
     }
 
     /// Build an IRI term by appending `suffix` to this namespace.
     ///
     /// Return an error if the concatenation produces an invalid IRI.
-    pub fn get<U>(&self, suffix: U) -> Result<Term<T>>
+    pub fn get<U>(&self, suffix: U) -> TermResult<Term<T>>
     where
         T: From<U>,
     {

--- a/sophia/src/parser.rs
+++ b/sophia/src/parser.rs
@@ -30,3 +30,6 @@ pub mod rio_trig;
 pub mod rio_turtle;
 #[cfg(feature = "xml")]
 pub mod xml;
+
+mod _error;
+pub use self::_error::*;

--- a/sophia/src/parser/_error.rs
+++ b/sophia/src/parser/_error.rs
@@ -1,0 +1,75 @@
+use thiserror::Error;
+use pest::error::{Error as PestError, ErrorVariant, InputLocation, LineColLocation};
+use std::io;
+use crate::term::TermError;
+
+pub type ParserResult<T> = Result<T, ParserError>;
+
+#[derive(Debug, Error)]
+pub enum ParserError {
+	#[error("Custom: {msg}")]
+	Custom { msg: String },
+	#[error("ParserFailed: at {}: {msg}", display_location(.location, .line_col))]
+	Located { msg: String, location: InputLocation, line_col: LineColLocation},
+	#[error("IoFailed: {source}")]
+	Io { #[from] source: io::Error },
+	#[error("IoFailed at line {line}: {source}")]
+	IoAt { source: io::Error, line: usize },
+	#[error("InvalidTerm: {source}")]
+	InvalidTerm { #[from] source: TermError },
+}
+
+impl From<String> for ParserError {
+	fn from(msg: String) -> Self {
+		Self::Custom { msg }
+	}
+}
+
+impl ParserError {
+	pub fn new_located(msg: String, line_offset: usize) -> Self {
+		let location = InputLocation::Pos(0);
+		let line_col = LineColLocation::Pos((line_offset, 0));
+		ParserError::Located { msg, location, line_col }
+	}
+	/// Utility function for converting [Pest] errors into [Sophia errors](../../error/index.html).
+	///
+	/// [Pest]: https://docs.rs/crate/pest/
+	///
+	pub fn from_pest_err<R: pest::RuleType>(err: PestError<R>, lineoffset: usize) -> Self {
+		let msg = match err.variant {
+			ErrorVariant::ParsingError {
+				positives,
+				negatives,
+			} => format!("expected: {:?}\nunexpected: {:?}", positives, negatives),
+			ErrorVariant::CustomError { message } => message,
+		};
+		let location = err.location.clone();
+		use ::pest::error::LineColLocation::*;
+		let line_col = match err.line_col.clone() {
+			Pos((l, c)) => Pos((l + lineoffset, c)),
+			Span((l1, c1), (l2, c2)) => Span((l1 + lineoffset, c1), (l2 + lineoffset, c2)),
+		};
+		ParserError::Located { msg, location, line_col }
+	}
+	pub fn from_io_at(source: io::Error, line: usize) -> Self {
+		Self::IoAt {source, line}
+	}
+}
+
+fn display_location(il: &InputLocation, lcl: &LineColLocation) -> String {
+	let line = *match lcl {
+		LineColLocation::Pos((line, _)) => line,
+		LineColLocation::Span((line, _), _) => line,
+	};
+	if line == 0 {
+		match il {
+			InputLocation::Pos(pos) => format!("{}", pos),
+			InputLocation::Span((s, e)) => format!("{}-{}", s, e),
+		}
+	} else {
+		match lcl {
+			LineColLocation::Pos((l, c)) => format!("{}:{}", l, c),
+			LineColLocation::Span((l1, c1), (l2, c2)) => format!("{}:{}-{}:{}", l1, c1, l2, c2),
+		}
+	}
+}

--- a/sophia/src/serializer/_error.rs
+++ b/sophia/src/serializer/_error.rs
@@ -1,0 +1,27 @@
+use thiserror::Error;
+use std::io;
+use crate::error::Infallible;
+
+pub type SerializationResult<T> = Result<T, SerializationError>;
+
+#[derive(Debug, Error)]
+pub enum SerializationError {
+	#[error("Custom: {msg}")]
+	Custom { msg: String },
+	#[error("IO: {source}")]
+	Io { #[from] source: io::Error },
+}
+
+impl From<String> for SerializationError {
+	fn from(msg: String) -> Self {
+		Self::Custom { msg }
+	}
+}
+
+impl From<Infallible> for SerializationError {
+	/// This implementation is only for support of the type system.
+	/// As `Infallible` can not be instantiatet this will never execute.
+	fn from(_: Infallible) -> Self {
+		unreachable!()
+	}
+}

--- a/sophia/src/serializer/common.rs
+++ b/sophia/src/serializer/common.rs
@@ -47,7 +47,7 @@ macro_rules! def_triple_stringifier {
 
         impl $crate::triple::stream::TripleSink for $stringifier {
             type Outcome = String;
-            type Error = $crate::error::Error;
+            type Error = $crate::serializer::SerializationError;
 
             fn feed<'a, T>(&mut self, t: &T) -> std::result::Result<(), Self::Error>
             where
@@ -93,7 +93,7 @@ macro_rules! def_quad_stringifier {
 
         impl $crate::quad::stream::QuadSink for $stringifier {
             type Outcome = String;
-            type Error = $crate::error::Error;
+            type Error = $crate::serializer::SerializationError;
 
             fn feed<'a, T>(&mut self, t: &T) -> std::result::Result<(), Self::Error>
             where

--- a/sophia/src/term/_error.rs
+++ b/sophia/src/term/_error.rs
@@ -1,0 +1,27 @@
+use thiserror::Error as ThisError;
+
+pub type TermResult<T> = Result<T, TermError>;
+
+#[derive(Debug, ThisError)]
+pub enum TermError {
+	#[error("Custom: {msg}")]
+	Custom { msg: String },
+	#[error("InvalidDatatype: {dt}")]
+	InvalidDatatype{ dt: String },
+	#[error("InvalidIri: {iri}")]
+	InvalidIri{ iri: String },
+	#[error("InvalidLanguageTag: {lang}: {msg}")]
+	InvalidLanguageTag{ lang: String, msg: String },
+	#[error("InvalidVariableName: {var}")]
+	InvalidVariableName{ var: String },
+	#[error("InvalidPrefix: {prefix}")]
+	InvalidPrefix{ prefix: String },
+	#[error("IriMustBeAbsolute: <{iri}>")]
+	IriMustBeAbsolute{ iri: String },
+}
+
+impl From<String> for TermError {
+	fn from(msg: String) -> Self {
+		Self::Custom { msg }
+	}
+}

--- a/sophia/src/term/_iri_data.rs
+++ b/sophia/src/term/_iri_data.rs
@@ -75,7 +75,7 @@ where
         Ok(())
     }
 
-    pub(crate) fn new(ns: T, suffix: Option<T>) -> Result<IriData<T>> {
+    pub(crate) fn new(ns: T, suffix: Option<T>) -> TermResult<IriData<T>> {
         let mut ret = IriData {
             ns,
             suffix,
@@ -86,7 +86,7 @@ where
         if ret.absolute || is_relative_iri(&val) {
             Ok(ret)
         } else {
-            Err(ErrorKind::InvalidIri("IRI is invalid".to_string()).into())
+            Err(TermError::InvalidIri { iri: "IRI is invalid".to_string() })
         }
     }
 

--- a/sophia/src/term/factory.rs
+++ b/sophia/src/term/factory.rs
@@ -18,14 +18,14 @@ pub trait TermFactory {
 
     fn get_term_data(&mut self, txt: &str) -> Self::TermData;
 
-    fn iri<T>(&mut self, iri: T) -> Result<FTerm<Self>>
+    fn iri<T>(&mut self, iri: T) -> TermResult<FTerm<Self>>
     where
         T: TermData,
     {
         Term::new_iri(self.get_term_data(iri.as_ref()))
     }
 
-    fn iri2<T, U>(&mut self, ns: T, suffix: U) -> Result<FTerm<Self>>
+    fn iri2<T, U>(&mut self, ns: T, suffix: U) -> TermResult<FTerm<Self>>
     where
         T: TermData,
         U: TermData,
@@ -36,14 +36,14 @@ pub trait TermFactory {
         )
     }
 
-    fn bnode<T>(&mut self, id: T) -> Result<FTerm<Self>>
+    fn bnode<T>(&mut self, id: T) -> TermResult<FTerm<Self>>
     where
         T: TermData,
     {
         Term::new_bnode(self.get_term_data(id.as_ref()))
     }
 
-    fn literal_lang<T, U>(&mut self, txt: T, lang: U) -> Result<FTerm<Self>>
+    fn literal_lang<T, U>(&mut self, txt: T, lang: U) -> TermResult<FTerm<Self>>
     where
         T: TermData,
         U: TermData,
@@ -54,7 +54,7 @@ pub trait TermFactory {
         )
     }
 
-    fn literal_dt<T, U>(&mut self, txt: T, dt: Term<U>) -> Result<FTerm<Self>>
+    fn literal_dt<T, U>(&mut self, txt: T, dt: Term<U>) -> TermResult<FTerm<Self>>
     where
         T: TermData,
         U: TermData,
@@ -63,7 +63,7 @@ pub trait TermFactory {
         Term::new_literal_dt(self.get_term_data(txt.as_ref()), self.copy(&dt))
     }
 
-    fn variable<T>(&mut self, name: T) -> Result<FTerm<Self>>
+    fn variable<T>(&mut self, name: T) -> TermResult<FTerm<Self>>
     where
         T: TermData,
     {

--- a/sophia/src/triple/stream.rs
+++ b/sophia/src/triple/stream.rs
@@ -9,12 +9,9 @@
 //! [`Iterator`]: https://doc.rust-lang.org/std/iter/trait.Iterator.html
 
 use std::iter::Map;
-
 use crate::error::*;
-use crate::graph::*;
 use crate::triple::*;
-
-use std::result::Result; // override ::error::Result
+use anyhow;
 
 /// A triple source produces [triples], and may also fail in the process.
 ///
@@ -32,50 +29,20 @@ pub trait TripleSource<'a> {
     type Triple: Triple<'a>;
 
     /// The type of errors produced by this source.
-    type Error: CoercibleWith<Error> + CoercibleWith<Never>;
+    type Error: SafeError;
 
     /// The type of iterator this triple source casts to.
     type Iter: Iterator<Item = Result<Self::Triple, Self::Error>>;
 
     /// Cast to iterator.
     fn as_iter(&mut self) -> &mut Self::Iter;
-
-    /// Feed all triples from this source into the given [sink](trait.TripleSink.html).
-    ///
-    /// Stop on the first error (in the source or the sink).
-    fn in_sink<TS: TripleSink>(
-        &mut self,
-        sink: &mut TS,
-    ) -> CoercedResult<TS::Outcome, Self::Error, TS::Error>
-    where
-        Self::Error: CoercibleWith<TS::Error>,
-    {
-        for tr in self.as_iter() {
-            let t = tr?;
-            sink.feed(&t)?;
-        }
-        Ok(sink.finish()?)
-    }
-
-    /// Insert all triples from this source into the given [graph](../../graph/trait.MutableGraph.html).
-    ///
-    /// Stop on the first error (in the source or in the graph).
-    fn in_graph<G: MutableGraph>(
-        &mut self,
-        graph: &mut G,
-    ) -> CoercedResult<usize, Self::Error, <G as MutableGraph>::MutationError>
-    where
-        Self::Error: CoercibleWith<<G as MutableGraph>::MutationError>,
-    {
-        self.in_sink(&mut graph.inserter())
-    }
 }
 
 impl<'a, I, T, E> TripleSource<'a> for I
 where
     I: Iterator<Item = Result<T, E>> + 'a,
     T: Triple<'a>,
-    E: CoercibleWith<Error> + CoercibleWith<Never>,
+    E: SafeError,
 {
     type Triple = T;
     type Error = E;
@@ -93,7 +60,7 @@ where
 /// [`Triple`]: ../trait.Triple.html
 pub trait AsTripleSource<T>: Sized {
     /// Map all items of this iterator into an Ok result.
-    fn as_triple_source(self) -> Map<Self, fn(T) -> OkResult<T>>;
+    fn as_triple_source(self) -> Map<Self, fn(T) -> Result<T, Infallible>>;
 }
 
 impl<'a, T, I> AsTripleSource<T> for I
@@ -101,22 +68,19 @@ where
     I: Iterator<Item = T> + 'a + Sized,
     T: Triple<'a>,
 {
-    fn as_triple_source(self) -> Map<Self, fn(T) -> OkResult<T>> {
-        self.map(Ok)
+    fn as_triple_source(self) -> Map<Self, fn(T) -> Result<T, Infallible>> {
+       self.map(Ok)
     }
 }
 
 /// A triple sink consumes [triples](../trait.Triple.html),
 /// produces a result, and may also fail in the process.
 ///
-/// Typical triple sinks are [serializer]
-/// or graphs' [inserters] and [removers].
+/// Typical triple sinks are [serializers].
 ///
 /// See also [`TripleSource`].
 ///
-/// [serializer]: ../../serializer/index.html
-/// [inserters]: ../../graph/trait.MutableGraph.html#method.inserter
-/// [removers]: ../../graph/trait.MutableGraph.html#method.remover
+/// [serializers]: ../../serializer/index.html
 /// [`TripleSource`]: trait.TripleSource.html
 ///
 pub trait TripleSink {
@@ -126,30 +90,34 @@ pub trait TripleSink {
     type Outcome;
 
     /// The type of error raised by this triple sink.
-    type Error: CoercibleWith<Error> + CoercibleWith<Never>;
+    type Error: SafeError;
 
     /// Feed one triple in this sink.
     fn feed<'a, T: Triple<'a>>(&mut self, t: &T) -> Result<(), Self::Error>;
+
+    fn feed_all<'a, TS>(&mut self, ts: TS) -> Result<(), anyhow::Error> 
+    where
+        TS: TripleSource<'a>,
+    {
+        let mut ts = ts;
+        for t in ts.as_iter() {
+            let t = t?;
+            self.feed(&t)?;
+        }
+        Ok(())
+    }
 
     /// Produce the result once all triples were fed.
     ///
     /// NB: the behaviour of a triple sink after `finish` is called is unspecified by this trait.
     fn finish(&mut self) -> Result<Self::Outcome, Self::Error>;
-}
 
-/// [`()`](https://doc.rust-lang.org/std/primitive.unit.html) acts as a "black hole",
-/// consuming all triples without erring, and producing no result.
-///
-/// Useful for benchmarking triple sources.
-impl TripleSink for () {
-    type Outcome = ();
-    type Error = Never;
-
-    fn feed<'a, T: Triple<'a>>(&mut self, _: &T) -> OkResult<()> {
-        Ok(())
-    }
-    fn finish(&mut self) -> OkResult<Self::Outcome> {
-        Ok(())
+    fn feed_all_and_finish<'a, TS>(&mut self, ts: TS) -> Result<Self::Outcome, anyhow::Error> 
+    where
+        TS: TripleSource<'a>,
+    {
+        self.feed_all(ts)?;
+        Ok(self.finish()?)
     }
 }
 


### PR DESCRIPTION
This PR changes the error-handling of sophia and some semantics of `XSource` and `XSink` traits.
I know, I shouldn't do two different things in one PR but I couldn't resist ... 

# Change in error-handling

This PR canges the error-handling in `sophia` from `error-chain` and `coercible-errors` to `thiserror` and `anyhow`.

## Specific errors

As mentioned in #8 is the `error-chain`-crate somewhat outdated. I choose the relatively new `thiserror` as it is very simple and easy to use. 
In addition the big `sophia::error::Error` is split into module-errors as suggested by [`snafu`](https://docs.rs/snafu/0.6.0/snafu/guide/philosophy/index.html#many-error-types). This will make it easier to split up `sophia` (#26) and reduces dependencies between the modules. Furthermore, it is someaht more aligned with the philosophie of "each implementation can provide its own error".

## Coliding error-types

This was handled by `coercible-errors` before and is changed to `anyhow`. It provides [`anyhow::Error`](https://docs.rs/anyhow/1.0.25/anyhow/struct.Error.html) which is "a better `Box<dyn Error>`". It can be created from anytype that implements `std::error::Error`, therefore, is suitable when different error-types colide.

As stated in `anyhow`'s [docs](https://docs.rs/anyhow/1.0.25/anyhow/index.html#details) can `anyhow::Error` be downcasted to a concrete error-type, so users can still match against concrete types, e.g. done in the parser test.

I don't want to offend `coercible-errors`. I just think the handling of many different errors will become more and more complicated as the `sophia`-ecosystem grows as implementers probably provide their own error-types. The complexity has been presented at `graph::Graph::retain()` which had a bizzar and complicated trait bound and now just returns `anyhow::Error`.

The merge-everything `anyhow::Error` is only used when two or more errors are used within one function. Everything else returns a specific error-type. This highlights better where the user has to be aware of error-mixing.

# Semantics of `Iterator`s

_When "Triples" are mentioned in the following section they can always be substituted with "Quads"_

The semantics of `TripleSource` and `TripleSink` always felt a bit cumbersome to me. As a result, I changed the semantics of them a bit.

## Consume sources

Often `Iterator`s where past in by `&mut` but `Iterator`s are designed to be consumed by iteration, therefore, it is more idomatic to move them into a function. Accordingly, I added `TripleSink::feed_all()` method that takes a `TripleSource`.

The semantic of a `TripleSink` is also not totaly clear to me. On the one hand there is the 'serializer'-sink that consumes and finishes just like `TripleSource`'s API suggests. On the other hand there are 'graph'-sinks that consume triples as-well but finishing them seems a bit unnatural. As a consequence, I removed the `Graph::inserter` and `Graph::remover` methods which are equally substituted by `Graph::insert_all` and `Graph::remove_all`.

## Create from TripleSource

The builder-pattern for graphs seemed a bit unidomatic for me. Consequently, I removed `in_sink` and `in_graph` methods and created the new `CollectToGraph`-trait which extends the standard `Iterator`. I think this is more accesible for Rust programmers as its more close to the standard API (cf. getting started example in `lib.rs`). I tried to implement something like `impl FromIterator for Result<Graph>` so user could just call `collect()?` on a `TripleSource` but this is vorbidden by Rust's orphan rule...

# Conclusion

I'm totally aware that these are huge changes and that you might think that some of them are to much. Most of the changes I did are for sake of better ergonomics and a more idomatic Rust. I am open to disucussion and l will gladly change the PR if required.
