### PR TITLE
Refactor error handling in mods graph and dataset

### DIFF
--- a/sophia/src/error.rs
+++ b/sophia/src/error.rs
@@ -5,14 +5,6 @@ use std::fmt;
 
 error_chain! {
     errors {
-        /// Raised by the methods of the [`Graph`](../graph/trait.Graph.html) trait.
-        GraphError(message: String) {
-            display("error while querying Graph: {}", message)
-        }
-        /// Raised by the methods of the [`MutableGraph`](../graph/trait.MutableGraph.html) trait.
-        GraphMutationError(msg: String) {
-            display("error while modifying Graph: {}", msg)
-        }
         /// Raised whenever an invalid prefix is used in a PName.
         InvalidPrefix(prefix: String) {
             display("invalid prefix <{}>", prefix)
@@ -28,10 +20,6 @@ error_chain! {
         /// Raised by serializers when they encounter a problem.
         SerializerError(message: String) {
             display("error while serializing: {}", message)
-        }
-        /// Raised by some mutable dataset
-        UnsupportedGraphName(graph_name: String) {
-            display("unsupported graph_name: {}", graph_name)
         }
         /// Raised by some mutable dataset
         TermError(te: TermError) {

--- a/sophia/src/graph/adapter.rs
+++ b/sophia/src/graph/adapter.rs
@@ -319,7 +319,6 @@ impl<G, H> MutableDataset for GraphAsDataset<G, H>
 where
     G: MutableGraph,
     H: BorrowMut<G>,
-    GraphAsDatasetError<G::MutationError>: From<G::MutationError>,
 {
     type MutationError = GraphAsDatasetError<G::MutationError>;
 

--- a/sophia/src/graph/adapter/_error.rs
+++ b/sophia/src/graph/adapter/_error.rs
@@ -1,0 +1,23 @@
+use std::error::Error;
+
+/// This error is raised by the [adapter] from [`MutableGraph`] to [`MutableDataset`].
+///
+/// _Note:_ MGE is the [mutation error] of the wrapped [`MutableGraph`].
+///
+/// [adapter]: ./struct.GraphAsDataset.html
+/// [`MutableGraph`]: ../trait.MutableGraph.html
+/// [`MutableDataset`]: ../../dataset/trait.MutableDataset.html
+/// [mutation error]: ../trait.MutableGraph.html#associatedtype.MutationError
+#[derive(Debug, thiserror::Error)]
+pub enum GraphAsDatasetError<MGE: 'static + Error> {
+	/// Raised when the [adapter] is requested to modify a triple in a named
+	/// `Graph` which is not supported as it is only a singel `Graph` wrapped.
+	///
+	/// [adapter]: ./struct.GraphAsDataset.html
+	///
+	#[error("GraphAsDataset does not support named graphs")]
+	GraphNamesNotSupported,
+	/// Error from the wrapped `Graph`
+    #[error("{0}")]
+    FromGraph(#[from] MGE),
+}

--- a/sophia/src/graph/adapter/_error.rs
+++ b/sophia/src/graph/adapter/_error.rs
@@ -10,14 +10,14 @@ use std::error::Error;
 /// [mutation error]: ../trait.MutableGraph.html#associatedtype.MutationError
 #[derive(Debug, thiserror::Error)]
 pub enum GraphAsDatasetError<MGE: 'static + Error> {
-	/// Raised when the [adapter] is requested to modify a triple in a named
-	/// `Graph` which is not supported as it is only a singel `Graph` wrapped.
-	///
-	/// [adapter]: ./struct.GraphAsDataset.html
-	///
-	#[error("GraphAsDataset does not support named graphs")]
-	GraphNamesNotSupported,
-	/// Error from the wrapped `Graph`
+    /// Raised when the [adapter] is requested to modify a triple in a named
+    /// `Graph` which is not supported as it is only a singel `Graph` wrapped.
+    ///
+    /// [adapter]: ./struct.GraphAsDataset.html
+    ///
+    #[error("GraphAsDataset does not support named graphs")]
+    GraphNamesNotSupported,
+    /// Error from the wrapped `Graph`
     #[error("{0}")]
     FromGraph(#[from] MGE),
 }


### PR DESCRIPTION
Continuation of #8 .

Removes unnecessary error variants from `sophia::error::Error` and adds a new error for the `Graph` to `Dataset` wrapper.

### Future work

At investigating `GraphAsDataset<G, H>` I recognized that the second parameter `H` is used nowhere actually. I could remove this within this PR if you like or did I missed something?

@pchampin It seems to me that the mods parser and serializer are currently adapted to the `rio` crates. Is this work finished and I can continue refactoring the error handling or should I wait?