### PR TITLE
making the namespace! macro public

### DIFF
--- a/sophia/src/ns.rs
+++ b/sophia/src/ns.rs
@@ -60,6 +60,7 @@ macro_rules! namespace {
     }
 }
 
+#[macro_export]
 macro_rules! ns_term {
     ($prefix:expr, $ident:ident) => {
         ns_term!($prefix, $ident, stringify!($ident));

--- a/sophia/src/term/_iri_data.rs
+++ b/sophia/src/term/_iri_data.rs
@@ -21,9 +21,9 @@ use super::*;
 /// for more detail.
 #[derive(Clone, Copy, Debug, Eq)]
 pub struct IriData<T: AsRef<str>> {
-    pub(crate) ns: T,
-    pub(crate) suffix: Option<T>,
-    pub(crate) absolute: bool,
+    pub ns: T,
+    pub suffix: Option<T>,
+    pub absolute: bool,
 }
 
 impl<T> IriData<T>


### PR DESCRIPTION
Hi, I'd love to use the `sophia::ns::namespace!` macro for my own projects, but I had to make a couple of changes to the code to make it work. I suspect making the fields on `IriData` public is not something you desire, but perhaps we can have a discussion about how to make this work? (btw, I am a neophyte Rust programmer)