### PR TITLE
Minor changes to serializers

### DIFF
--- a/sophia/src/serializer.rs
+++ b/sophia/src/serializer.rs
@@ -28,7 +28,7 @@ pub trait TripleSerializer {
     /// [`TripleSource`]: ../triple/stream/trait.TripleSource.html
     fn serialize_triples<TS>(
         &mut self,
-        source: &mut TS,
+        source: TS,
     ) -> StreamResult<&mut Self, TS::Error, Self::Error>
     where
         TS: TripleSource,
@@ -47,7 +47,7 @@ pub trait TripleSerializer {
         G: Graph,
         Self: Sized,
     {
-        self.serialize_triples(&mut graph.triples())
+        self.serialize_triples(graph.triples())
     }
 }
 
@@ -60,7 +60,7 @@ pub trait QuadSerializer {
     /// [`QuadSource`]: ../quad/stream/trait.QuadSource.html
     fn serialize_quads<QS>(
         &mut self,
-        source: &mut QS,
+        source: QS,
     ) -> StreamResult<&mut Self, QS::Error, Self::Error>
     where
         QS: QuadSource,
@@ -82,7 +82,7 @@ pub trait QuadSerializer {
         D: Dataset,
         Self: Sized,
     {
-        self.serialize_quads(&mut dataset.quads())
+        self.serialize_quads(dataset.quads())
     }
 }
 

--- a/sophia/src/serializer/nq.rs
+++ b/sophia/src/serializer/nq.rs
@@ -61,10 +61,7 @@ where
 {
     type Error = io::Error;
 
-    fn serialize_quads<QS>(
-        &mut self,
-        source: QS,
-    ) -> StreamResult<&mut Self, QS::Error, Self::Error>
+    fn serialize_quads<QS>(&mut self, source: QS) -> StreamResult<&mut Self, QS::Error, Self::Error>
     where
         QS: QuadSource,
     {

--- a/sophia/src/serializer/nt.rs
+++ b/sophia/src/serializer/nt.rs
@@ -63,7 +63,7 @@ where
 
     fn serialize_triples<TS>(
         &mut self,
-        source: &mut TS,
+        source: TS,
     ) -> StreamResult<&mut Self, TS::Error, Self::Error>
     where
         TS: TripleSource,
@@ -71,31 +71,31 @@ where
         if self.config.ascii {
             todo!("Pure-ASCII N-Triples is not implemented yet")
         }
+        let mut source = source;
         source
             .try_for_each_triple(|t| {
-                let w = &mut self.write;
-                writeln!(w, "{} {} {} .", t.s(), t.p(), t.o())
+                writeln!(self.write, "{} {} {} .", t.s(), t.p(), t.o())
                     .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
             })
             .map(|_| self)
     }
 }
 
-type NtStringifier = NtSerializer<Vec<u8>>;
-
-impl NtStringifier {
+impl NtSerializer<Vec<u8>> {
+    /// Create a new serializer wich targets a `String`.
     #[inline]
-    pub fn new_stringifier() -> NtStringifier {
-        NtSerializer::new(Vec::new())
+    pub fn new_stringifier() -> Self {
+        Self::new(Vec::new())
     }
 
+    /// Create a new serializer wich targets a `String` with a custom config.
     #[inline]
-    pub fn new_stringifier_with_config(config: NtConfig) -> NtStringifier {
-        NtSerializer::new_with_config(Vec::new(), config)
+    pub fn new_stringifier_with_config(config: NtConfig) -> Self {
+        Self::new_with_config(Vec::new(), config)
     }
 }
 
-impl Stringifier for NtStringifier {
+impl Stringifier for NtSerializer<Vec<u8>> {
     fn as_utf8(&self) -> &[u8] {
         &self.write[..]
     }


### PR DESCRIPTION
Response to #34 commit  9a97dae .

- Remove `&mut` from source  in serialize 'statement' methods.
  Unnesessary as sources are completely consumed (see doc: 'Serialize __all__ triples/quads').
- Remove `NxStringifier` type alias.
   Seems redundant to call `NtStringifier::new_stringifier()` when
   `NtSerializer::new_stringifier()` does the same.
- Rename `NtSerializer` to `NqSerializer` in nq.rs.