### PR TITLE
Variable as own type

### DIFF
--- a/sophia/Cargo.toml
+++ b/sophia/Cargo.toml
@@ -30,3 +30,6 @@ thiserror = "1.0.9"
 
 quick-xml = { version = "0.17.2", optional = true }
 percent-encoding = { version = "2.1.0", optional = true }
+
+[dev-dependencies]
+test-case = "1.0.0"

--- a/sophia/src/query.rs
+++ b/sophia/src/query.rs
@@ -135,8 +135,8 @@ where
 
 /// Make a matcher corresponding to term `t`, given binding `b`.
 fn matcher(t: &RcTerm, b: &BindingMap) -> Binding {
-    if let Variable(vname) = t {
-        let vname: &str = &vname;
+    if let Variable(var) = t {
+        let vname: &str = var.as_ref();
         b.get(vname).cloned().into()
     } else {
         Binding::Exactly(t.clone())

--- a/sophia/src/serializer/nq.rs
+++ b/sophia/src/serializer/nq.rs
@@ -29,24 +29,24 @@ impl NtConfig {
 }
 
 // N-Quads serializer.
-pub struct NtSerializer<W> {
+pub struct NqSerializer<W> {
     config: NtConfig,
     write: W,
 }
 
-impl<W> NtSerializer<W>
+impl<W> NqSerializer<W>
 where
     W: io::Write,
 {
     /// Build a new N-Quads serializer writing to `write`, with the default config.
     #[inline]
-    pub fn new(write: W) -> NtSerializer<W> {
+    pub fn new(write: W) -> NqSerializer<W> {
         Self::new_with_config(write, NtConfig::default())
     }
 
     /// Build a new N-Quads serializer writing to `write`, with the given config.
-    pub fn new_with_config(write: W, config: NtConfig) -> NtSerializer<W> {
-        NtSerializer { write, config }
+    pub fn new_with_config(write: W, config: NtConfig) -> NqSerializer<W> {
+        NqSerializer { write, config }
     }
 
     /// Borrow this serializer's configuration.
@@ -55,7 +55,7 @@ where
     }
 }
 
-impl<W> QuadSerializer for NtSerializer<W>
+impl<W> QuadSerializer for NqSerializer<W>
 where
     W: io::Write,
 {
@@ -87,21 +87,20 @@ where
     }
 }
 
-type NtStringifier = NtSerializer<Vec<u8>>;
-
-impl NtStringifier {
+impl NqSerializer<Vec<u8>> {
+    /// Create a new serializer wich targets a `String`.
     #[inline]
-    pub fn new_stringifier() -> NtStringifier {
-        NtSerializer::new(Vec::new())
+    pub fn new_stringifier() -> Self {
+        NqSerializer::new(Vec::new())
     }
-
+    /// Create a new serializer wich targets a `String` with a custom config.
     #[inline]
-    pub fn new_stringifier_with_config(config: NtConfig) -> NtStringifier {
-        NtSerializer::new_with_config(Vec::new(), config)
+    pub fn new_stringifier_with_config(config: NtConfig) -> Self {
+        NqSerializer::new_with_config(Vec::new(), config)
     }
 }
 
-impl Stringifier for NtStringifier {
+impl Stringifier for NqSerializer<Vec<u8>> {
     fn as_utf8(&self) -> &[u8] {
         &self.write[..]
     }
@@ -138,7 +137,7 @@ pub(crate) mod test {
                 Some(StaticTerm::new_iri("http://champin.net/").unwrap()),
             ),
         ];
-        let s = NtSerializer::new_stringifier()
+        let s = NqSerializer::new_stringifier()
             .serialize_dataset(&d)
             .unwrap()
             .to_string();

--- a/sophia/src/serializer/nt.rs
+++ b/sophia/src/serializer/nt.rs
@@ -81,21 +81,20 @@ where
     }
 }
 
-type NtStringifier = NtSerializer<Vec<u8>>;
-
-impl NtStringifier {
+impl NtSerializer<Vec<u8>> {
+    /// Create a new serializer wich targets a `String`.
     #[inline]
-    pub fn new_stringifier() -> NtStringifier {
+    pub fn new_stringifier() -> Self {
         NtSerializer::new(Vec::new())
     }
-
+    /// Create a new serializer wich targets a `String` with a custom config.
     #[inline]
-    pub fn new_stringifier_with_config(config: NtConfig) -> NtStringifier {
+    pub fn new_stringifier_with_config(config: NtConfig) -> Self {
         NtSerializer::new_with_config(Vec::new(), config)
     }
 }
 
-impl Stringifier for NtStringifier {
+impl Stringifier for NtSerializer<Vec<u8>> {
     fn as_utf8(&self) -> &[u8] {
         &self.write[..]
     }

--- a/sophia/src/term.rs
+++ b/sophia/src/term.rs
@@ -47,6 +47,8 @@ pub mod iri_rfc3987;
 use self::iri_rfc3987::IriRefStructure;
 pub mod matcher;
 
+pub mod variable;
+
 mod _bnode_id;
 pub use self::_bnode_id::*;
 mod _convert;

--- a/sophia/src/term.rs
+++ b/sophia/src/term.rs
@@ -453,7 +453,7 @@ where
     }
 }
 
-impl<TD> From<Variable<TD>> for Term<TD> 
+impl<TD> From<Variable<TD>> for Term<TD>
 where
     TD: TermData,
 {

--- a/sophia/src/term.rs
+++ b/sophia/src/term.rs
@@ -48,6 +48,7 @@ use self::iri_rfc3987::IriRefStructure;
 pub mod matcher;
 
 pub mod variable;
+use self::variable::Variable;
 
 mod _bnode_id;
 pub use self::_bnode_id::*;
@@ -74,7 +75,7 @@ where
     Iri(IriData<T>),
     BNode(BNodeId<T>),
     Literal(T, LiteralKind<T>),
-    Variable(T),
+    Variable(Variable<T>),
 }
 pub use self::Term::*;
 
@@ -182,14 +183,10 @@ where
     /// May fail if `name` is not a valid variable name.
     pub fn new_variable<U>(name: U) -> Result<Term<T>>
     where
+        U: AsRef<str>,
         T: From<U>,
     {
-        let name = T::from(name);
-        if N3_VARIABLE_NAME.is_match(name.as_ref()) {
-            Ok(Variable(name))
-        } else {
-            Err(TermError::InvalidVariableName(name.as_ref().to_string()))
-        }
+        Variable::new(name).map(Into::into)
     }
 
     /// Copy another term with the given factory.
@@ -205,7 +202,7 @@ where
                 factory(value.as_ref()),
                 LiteralKind::from_with(kind, factory),
             ),
-            Variable(name) => Variable(factory(name.as_ref())),
+            Variable(var) => Variable(var.copy_with(factory)),
         }
     }
 
@@ -303,7 +300,7 @@ where
     where
         T: From<U>,
     {
-        Variable(T::from(name))
+        Variable::new_unchecked(name).into()
     }
 
     /// Return a copy of this term's underlying text.
@@ -317,7 +314,7 @@ where
             Iri(iri) => iri.to_string(),
             BNode(id) => String::from(id.as_ref()),
             Literal(value, _) => String::from(value.as_ref()),
-            Variable(name) => String::from(name.as_ref()),
+            Variable(var) => var.value(),
         }
     }
 
@@ -427,7 +424,7 @@ where
             (Literal(value1, kind1), Literal(value2, kind2)) => {
                 value1.as_ref() == value2.as_ref() && kind1 == kind2
             }
-            (Variable(name1), Variable(name2)) => name1.as_ref() == name2.as_ref(),
+            (Variable(var1), Variable(var2)) => var1 == var2,
             _ => false,
         }
     }
@@ -456,6 +453,15 @@ where
     }
 }
 
+impl<TD> From<Variable<TD>> for Term<TD> 
+where
+    TD: TermData,
+{
+    fn from(var: Variable<TD>) -> Self {
+        Term::Variable(var)
+    }
+}
+
 /// Check the equality of two graph names (`Option<&Term>`)
 /// using possibly different `TermData`.
 pub fn same_graph_name<T, U>(g1: Option<&Term<T>>, g2: Option<&Term<U>>) -> bool
@@ -468,15 +474,6 @@ where
         (None, None) => true,
         _ => false,
     }
-}
-
-lazy_static! {
-    static ref N3_VARIABLE_NAME: Regex = Regex::new(r"(?x)
-      ^
-      [A-Za-z\u{c0}-\u{d6}\u{d8}-\u{f6}\u{f8}-\u{2ff}\u{370}-\u{37D}\u{37F}-\u{1FFF}\u{200C}-\u{200D}\u{2070}-\u{218F}\u{2C00}-\u{2FEF}\u{3001}-\u{D7FF}\u{F900}-\u{FDCF}\u{FDF0}-\u{FFFD}\u{10000}-\u{EFFFF}_0-9]
-      [A-Za-z\u{c0}-\u{d6}\u{d8}-\u{f6}\u{f8}-\u{2ff}\u{370}-\u{37D}\u{37F}-\u{1FFF}\u{200C}-\u{200D}\u{2070}-\u{218F}\u{2C00}-\u{2FEF}\u{3001}-\u{D7FF}\u{F900}-\u{FDCF}\u{FDF0}-\u{FFFD}\u{10000}-\u{EFFFF}_0-9\u{00B7}\u{0300}-\u{036F}\u{203F}-\u{2040}]*
-      $
-    ").unwrap();
 }
 
 #[cfg(test)]

--- a/sophia/src/term/_display.rs
+++ b/sophia/src/term/_display.rs
@@ -53,9 +53,8 @@ where
                 w.write_char('>')?;
             }
         }
-        Variable(name) => {
-            w.write_char('?')?;
-            w.write_str(name.as_ref())?;
+        Variable(var) => {
+            var.write_fmt(w)?;
         }
     };
     Ok(())

--- a/sophia/src/term/_error.rs
+++ b/sophia/src/term/_error.rs
@@ -17,4 +17,7 @@ pub enum TermError {
     /// Names of variables must apply to SPARQL's [production rules](https://www.w3.org/TR/sparql11-query/#rVARNAME).
     #[error("The name '{0}' is not valid for a variable according to the SPARQL specification")]
     InvalidVariableName(String),
+    /// Raised when failing to downcast a term.
+    #[error("The term '{term}' is not the expected {expect}")]
+    UnexpectedKindOfTerm{ term: String, expect: String },
 }

--- a/sophia/src/term/_error.rs
+++ b/sophia/src/term/_error.rs
@@ -1,5 +1,8 @@
 use thiserror::Error;
 
+/// Type alias for `Result` with default error `TermError`.
+/// 
+/// Can be used like `std::result::Result` as well.
 pub type Result<T, E = TermError> = std::result::Result<T, E>;
 
 /// This error is raised when the creation of a term fails.
@@ -19,5 +22,5 @@ pub enum TermError {
     InvalidVariableName(String),
     /// Raised when failing to downcast a term.
     #[error("The term '{term}' is not the expected {expect}")]
-    UnexpectedKindOfTerm{ term: String, expect: String },
+    UnexpectedKindOfTerm { term: String, expect: String },
 }

--- a/sophia/src/term/variable.rs
+++ b/sophia/src/term/variable.rs
@@ -1,0 +1,177 @@
+//! Variables like used in SPARQL or universally quantified variables in 
+//! Notation3.
+//! 
+
+use super::{TermData, TermError, Result};
+use regex::Regex;
+use lazy_static::lazy_static;
+use std::fmt;
+use std::io;
+
+lazy_static! {
+    /// Production of SPARQL's VARNAME according to the
+    /// [SPARQL spec](https://www.w3.org/TR/sparql11-query/#rVARNAME).
+    /// 
+    /// _Note:_ This regular expression matches the whole input (`^...$`),
+    /// therefore, it can not be used to capture `VARNAME`s in an arbitrary
+    /// string.
+    ///
+    /// `VARNAME ::= ( PN_CHARS_U | [0-9] ) ( PN_CHARS_U | [0-9] | #x00B7 | [#x0300-#x036F] | [#x203F-#x2040] )*`
+    pub static ref VARNAME: Regex = Regex::new(r#"(?x)
+      ^
+      [_A-Za-z0-9\u{C0}-\u{D6}\u{D8}-\u{F6}\u{F8}-\u{2FF}\u{370}-\u{37D}\u{37F}-\u{1FFF}\u{200C}-\u{200D}\u{2070}-\u{218F}\u{2C00}-\u{2FEF}\u{3001}-\u{D7FF}\u{F900}-\u{FDCF}\u{FDF0}-\u{FFFD}\U{10000}-\U{EFFFF}]
+      [_A-Za-z0-9\u{B7}\u{C0}-\u{D6}\u{D8}-\u{F6}\u{F8}-\u{2FF}\u{300}-\u{37D}\u{37F}-\u{1FFF}\u{200C}-\u{200D}\u{203F}-\u{2040}\u{2070}-\u{218F}\u{2C00}-\u{2FEF}\u{3001}-\u{D7FF}\u{F900}-\u{FDCF}\u{FDF0}-\u{FFFD}\U{10000}-\U{EFFFF}]*
+      $
+    "#).unwrap();
+}
+
+/// A variable as an RDF term.
+///
+/// Defined in SPARQL and Noation3. However, `sophia` allows them generally
+/// everywhere. Serializers and parsers might deny them.
+#[derive(Clone, Copy, Debug, Eq, Hash)]
+pub struct Variable<TD: TermData>(TD);
+
+impl<TD> Variable<TD> 
+where
+    TD: TermData
+{
+    /// Return a new variable term with the given name.
+    ///
+    /// May fail if `name` is not a valid variable name.
+    pub fn new<U>(name: U) -> Result<Self>
+    where
+        U: AsRef<str>,
+        TD: From<U>,
+    {
+        if VARNAME.is_match(name.as_ref()) {
+            Ok(Variable(name.into()))
+        } else {
+            Err(TermError::InvalidVariableName(name.as_ref().to_string()))
+        }
+    }
+
+    /// Return a new variable term.
+    ///
+    /// # Safety
+    /// This function requires that `name` is a valid variable name.
+    pub unsafe fn new_unchecked<U>(name: U) -> Self
+    where
+        TD: From<U>,
+    {
+        Variable(name.into())
+    }
+
+    /// Copy self while transforming the inner `TermData` with the given 
+    /// factory.
+    pub fn copy_with<'a, U, F>(&'a self, mut factory: F) -> Variable<U>
+    where
+        U: TermData + From<&'a str>,
+        F: FnMut(&'a str) -> U,
+    {
+        Variable(factory(self.0.as_ref()))
+    }
+
+    // Writes a variable to the `fmt::Write` using the N3/SPARQL syntax.
+    pub fn write_fmt<W>(&self, w: &mut W) -> fmt::Result
+    where
+        W: fmt::Write,
+    {
+        w.write_char('?')?;
+        w.write_str(self.0.as_ref())
+    }
+
+    // Writes a variable to the `io::Write` using the N3/SPARQL syntax.
+    pub fn write_io<W>(&self, w: &mut W) -> io::Result<()>
+    where
+        W: io::Write,
+    {
+        w.write_all(b"?")?;
+        w.write_all(self.0.as_ref().as_bytes())
+    }
+}
+
+impl<T, U> PartialEq<Variable<U>> for Variable<T>
+where
+    T: TermData,
+    U: TermData,
+{
+    fn eq(&self, other: &Variable<U>) -> bool {
+        self.0.as_ref() == other.0.as_ref()
+    }
+}
+
+impl<TD> fmt::Display for Variable<TD>
+where
+    TD: TermData,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.write_fmt(f)
+    }
+}
+
+impl<'a, T, U> From<&'a Variable<U>> for Variable<T>
+where
+    T: TermData + From<&'a str>,
+    U: TermData,
+{
+    fn from(other: &'a Variable<U>) -> Self {
+        other.copy_with(T::from)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use test_case::test_case;
+
+    #[test_case("" => false ; "empty")]
+    #[test_case("hans" => true ; "no questionmark")]
+    #[test_case("ha?ns" => false ; "include unallowed char")]
+    #[test_case("_" => true ; "underscore")]
+    #[test_case("1" => true ; "number")]
+    #[test_case("hans_the_1" => true ; "mixed")]
+    fn check_regex(to_check: &str) -> bool {
+        VARNAME.is_match(to_check)
+    }
+
+    #[test_case("" => "invalid name" ; "empty")]
+    #[test_case("hans" => "?hans" ; "no questionmark")]
+    #[test_case("ha?ns" => "invalid name" ; "include unallowed char")]
+    #[test_case("_" => "?_" ; "underscore")]
+    #[test_case("1" => "?1" ; "number")]
+    #[test_case("hans_the_1" => "?hans_the_1" ; "mixed")]
+    fn check_write_fmt(to_check: &str) -> String {
+        let var: Variable<&str> = if let Ok(var) = Variable::new(to_check) {
+            var
+        } else {
+            return "invalid name".to_owned();
+        };
+
+        let mut buf = String::new();
+        match var.write_fmt(&mut buf) {
+            Ok(_) => buf,
+            Err(_) => "failed write".to_owned(),
+        }
+    }
+
+    #[test_case("" => b"invalid name".to_vec() ; "empty")]
+    #[test_case("hans" => b"?hans".to_vec() ; "no questionmark")]
+    #[test_case("ha?ns" => b"invalid name".to_vec() ; "include unallowed char")]
+    #[test_case("_" => b"?_".to_vec() ; "underscore")]
+    #[test_case("1" => b"?1".to_vec() ; "number")]
+    #[test_case("hans_the_1" => b"?hans_the_1".to_vec() ; "mixed")]
+    fn check_write_io(to_check: &str) -> Vec<u8> {
+        let var: Variable<&str> = if let Ok(var) = Variable::new(to_check) {
+            var
+        } else {
+            return b"invalid name".to_vec();
+        };
+
+        let mut buf = Vec::new();
+        match var.write_io(&mut buf) {
+            Ok(_) => buf,
+            Err(_) => b"failed write".to_vec(),
+        }
+    }
+}

--- a/sophia/src/term/variable.rs
+++ b/sophia/src/term/variable.rs
@@ -1,18 +1,18 @@
-//! Variables like used in SPARQL or universally quantified variables in 
+//! Variables like used in SPARQL or universally quantified variables in
 //! Notation3.
-//! 
+//!
 
-use super::{Term, TermData, TermError, Result};
-use regex::Regex;
+use super::{Result, Term, TermData, TermError};
 use lazy_static::lazy_static;
+use regex::Regex;
+use std::convert;
 use std::fmt;
 use std::io;
-use std::convert;
 
 lazy_static! {
     /// Production of SPARQL's VARNAME according to the
     /// [SPARQL spec](https://www.w3.org/TR/sparql11-query/#rVARNAME).
-    /// 
+    ///
     /// _Note:_ This regular expression matches the whole input (`^...$`),
     /// therefore, it can not be used to capture `VARNAME`s in an arbitrary
     /// string.
@@ -33,9 +33,9 @@ lazy_static! {
 #[derive(Clone, Copy, Debug, Eq, Hash)]
 pub struct Variable<TD: TermData>(TD);
 
-impl<TD> Variable<TD> 
+impl<TD> Variable<TD>
 where
-    TD: TermData
+    TD: TermData,
 {
     /// Return a new variable term with the given name.
     ///
@@ -63,7 +63,7 @@ where
         Variable(name.into())
     }
 
-    /// Copy self while transforming the inner `TermData` with the given 
+    /// Copy self while transforming the inner `TermData` with the given
     /// factory.
     pub fn copy_with<'a, U, F>(&'a self, mut factory: F) -> Variable<U>
     where
@@ -117,7 +117,7 @@ where
 }
 
 impl<TD> convert::AsRef<str> for Variable<TD>
-where 
+where
     TD: TermData,
 {
     /// As variable is merly a wrapper around `TermData`.
@@ -136,7 +136,7 @@ where
     }
 }
 
-impl<TD> convert::TryFrom<Term<TD>> for Variable<TD> 
+impl<TD> convert::TryFrom<Term<TD>> for Variable<TD>
 where
     TD: TermData,
 {
@@ -145,7 +145,10 @@ where
     fn try_from(term: Term<TD>) -> Result<Self, Self::Error> {
         match term {
             Term::Variable(var) => Ok(var),
-            _ => Err(TermError::UnexpectedKindOfTerm { term: term.to_string(), expect: "variable".to_owned() }),
+            _ => Err(TermError::UnexpectedKindOfTerm {
+                term: term.to_string(),
+                expect: "variable".to_owned(),
+            }),
         }
     }
 }


### PR DESCRIPTION
Contribution according to the discussions in #34 and #35.

As a first step this moves variables out of `Term` and into an own type `Variable`.

Following features are implemented:

- (unsafe) constructor
- copy with factory
- write to fmt/io
- convert between `Term` and `Variable` back and forth
- Integration of `Variable` in the methods of `Term`
- own public submodule `sophia::term::variable`

---

Step by step each kind of RDF term will get its own public submodule. I started with variables due to their small codebase. 
I think it is better to continue this process in small PRs rather then working weeks on an own branch and resolving ocuring conflicts in the end.