### PR TITLE
Fix 'sophia_term' dependency

### DIFF
--- a/sophia/Cargo.toml
+++ b/sophia/Cargo.toml
@@ -18,7 +18,7 @@ default = []
 xml = ["lazy_static", "percent-encoding", "quick-xml", "regex", "url"]
 
 [dependencies]
-sophia_term = "0.4"
+sophia_term = { version = "0.1.0", path = "../term" }
 resiter = "0.4.0"
 rio_api = { version = "0.4.1", features = ["generalized"] }
 rio_turtle = { version = "0.4.0", features = ["generalized"] }

--- a/term/Cargo.toml
+++ b/term/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sophia_term"
-version = "0.4.0"
+version = "0.1.0"
 authors = ["Pierre-Antoine Champin <pchampin@liris.cnrs.fr>"]
 edition = "2018"
 description = "A Rust toolkit for RDF and Linked Data - Types for RDF terms"


### PR DESCRIPTION
As 'sophia_term' is not yet published, the dependency in `sophia/Cargo.toml` throughs an error if a crate depends on `sophia`'s git. Fixed by adding a relative path.

In addition, set version of 'sophia_term' to 0.1.0 as it is a new crate.