### PR TITLE
Remove resiter dependency in the tests of dataset / graphs

### DIFF
--- a/sophia/src/dataset/test.rs
+++ b/sophia/src/dataset/test.rs
@@ -91,7 +91,13 @@ pub fn populate_nodes_types<D: MutableDataset>(d: &mut D) -> MDResult<D, ()> {
     Ok(())
 }
 
-pub fn as_box_q<Q: Quad>(quad: Q) -> ([BoxTerm; 3], Option<BoxTerm>) {
+pub fn as_box_q<Q: Quad, E>(quad: Result<Q, E>) -> ([BoxTerm; 3], Option<BoxTerm>) 
+{
+    let quad = match quad {
+        Ok(q) => q,
+        Err(_) => panic!("as_box_q received an error")
+    };
+    
     (
         [quad.s().into(), quad.p().into(), quad.o().into()],
         quad.g().map(|n| n.into()),
@@ -148,7 +154,6 @@ macro_rules! test_dataset_impl {
     ($module_name: ident, $mutable_dataset_impl: ident, $is_set: expr, $mutable_dataset_factory: path) => {
         #[cfg(test)]
         mod $module_name {
-            use resiter::oks::*;
             use sophia_term::{matcher::ANY, *};
             use $crate::dataset::test::*;
             use $crate::dataset::*;
@@ -330,7 +335,7 @@ macro_rules! test_dataset_impl {
                 let quads = d.quads();
                 let hint = quads.size_hint();
                 for iter in vec![quads, d.quads_matching(&ANY, &ANY, &ANY, &ANY)] {
-                    let v: Vec<_> = iter.oks().map(as_box_q).collect();
+                    let v: Vec<_> = iter.map(as_box_q).collect();
                     assert_eq!(v.len(), d.quads().count());
                     assert_consistent_hint(v.len(), hint);
                     assert!(Dataset::contains(&v, &C1, &rdf::type_, &rdfs::Class, *DG)?);
@@ -348,7 +353,7 @@ macro_rules! test_dataset_impl {
                 let quads = d.quads_with_s(&C2);
                 let hint = quads.size_hint();
                 for iter in vec![quads, d.quads_matching(&*C2, &ANY, &ANY, &ANY)] {
-                    let v: Vec<_> = iter.oks().map(as_box_q).collect();
+                    let v: Vec<_> = iter.map(as_box_q).collect();
                     assert_eq!(v.len(), 2);
                     assert_consistent_hint(v.len(), hint);
                     assert!(Dataset::contains(&v, &C2, &rdf::type_, &rdfs::Class, *DG)?);
@@ -378,7 +383,7 @@ macro_rules! test_dataset_impl {
                 let quads = d.quads_with_p(&rdfs::subClassOf);
                 let hint = quads.size_hint();
                 for iter in vec![quads, d.quads_matching(&ANY, &rdfs::subClassOf, &ANY, &ANY)] {
-                    let v: Vec<_> = iter.oks().map(as_box_q).collect();
+                    let v: Vec<_> = iter.map(as_box_q).collect();
                     assert_eq!(v.len(), 1);
                     assert_consistent_hint(v.len(), hint);
                     assert!(Dataset::contains(&v, &C2, &rdfs::subClassOf, &C1, *GN1)?);
@@ -402,7 +407,7 @@ macro_rules! test_dataset_impl {
                 let quads = d.quads_with_o(&I2B);
                 let hint = quads.size_hint();
                 for iter in vec![quads, d.quads_matching(&ANY, &ANY, &*I2B, &ANY)] {
-                    let v: Vec<_> = iter.oks().map(as_box_q).collect();
+                    let v: Vec<_> = iter.map(as_box_q).collect();
                     assert_eq!(v.len(), 2);
                     assert_consistent_hint(v.len(), hint);
                     assert!(Dataset::contains(&v, &I1B, &P1, &I2B, *GN2)?);
@@ -420,7 +425,7 @@ macro_rules! test_dataset_impl {
                 let quads = d.quads_with_g(*GN1);
                 let hint = quads.size_hint();
                 for iter in vec![quads, d.quads_matching(&ANY, &ANY, &ANY, &*GN1)] {
-                    let v: Vec<_> = iter.oks().map(as_box_q).collect();
+                    let v: Vec<_> = iter.map(as_box_q).collect();
                     assert_eq!(v.len(), 6);
                     assert_consistent_hint(v.len(), hint);
                     assert!(Dataset::contains(&v, &C1, &rdf::type_, &rdfs::Class, *GN1)?);
@@ -438,7 +443,7 @@ macro_rules! test_dataset_impl {
                 let quads = d.quads_with_sp(&C2, &rdf::type_);
                 let hint = quads.size_hint();
                 for iter in vec![quads, d.quads_matching(&*C2, &rdf::type_, &ANY, &ANY)] {
-                    let v: Vec<_> = iter.oks().map(as_box_q).collect();
+                    let v: Vec<_> = iter.map(as_box_q).collect();
                     assert_eq!(v.len(), 1);
                     assert_consistent_hint(v.len(), hint);
                     assert!(Dataset::contains(&v, &C2, &rdf::type_, &rdfs::Class, *DG)?);
@@ -462,7 +467,7 @@ macro_rules! test_dataset_impl {
                 let quads = d.quads_with_so(&C2, &C1);
                 let hint = quads.size_hint();
                 for iter in vec![quads, d.quads_matching(&*C2, &ANY, &*C1, &ANY)] {
-                    let v: Vec<_> = iter.oks().map(as_box_q).collect();
+                    let v: Vec<_> = iter.map(as_box_q).collect();
                     assert_eq!(v.len(), 1);
                     assert_consistent_hint(v.len(), hint);
                     assert!(Dataset::contains(&v, &C2, &rdfs::subClassOf, &C1, *GN1)?);
@@ -483,7 +488,7 @@ macro_rules! test_dataset_impl {
                     quads,
                     d.quads_matching(&ANY, &rdf::type_, &rdfs::Class, &ANY),
                 ] {
-                    let v: Vec<_> = iter.oks().map(as_box_q).collect();
+                    let v: Vec<_> = iter.map(as_box_q).collect();
                     assert_eq!(v.len(), 3);
                     assert_consistent_hint(v.len(), hint);
                     assert!(Dataset::contains(&v, &C1, &rdf::type_, &rdfs::Class, *DG)?);
@@ -513,7 +518,7 @@ macro_rules! test_dataset_impl {
                 let quads = d.quads_with_sg(&C2, *GN1);
                 let hint = quads.size_hint();
                 for iter in vec![quads, d.quads_matching(&*C2, &ANY, &ANY, &*GN1)] {
-                    let v: Vec<_> = iter.oks().map(as_box_q).collect();
+                    let v: Vec<_> = iter.map(as_box_q).collect();
                     assert_eq!(v.len(), 1);
                     assert_consistent_hint(v.len(), hint);
                     assert!(Dataset::contains(&v, &C2, &rdfs::subClassOf, &C1, *GN1)?);
@@ -531,7 +536,7 @@ macro_rules! test_dataset_impl {
                 let quads = d.quads_with_pg(&rdf::type_, *GN1);
                 let hint = quads.size_hint();
                 for iter in vec![quads, d.quads_matching(&ANY, &rdf::type_, &ANY, &*GN1)] {
-                    let v: Vec<_> = iter.oks().map(as_box_q).collect();
+                    let v: Vec<_> = iter.map(as_box_q).collect();
                     assert_eq!(v.len(), 1);
                     assert_consistent_hint(v.len(), hint);
                     assert!(Dataset::contains(&v, &C1, &rdf::type_, &rdfs::Class, *GN1)?);
@@ -549,7 +554,7 @@ macro_rules! test_dataset_impl {
                 let quads = d.quads_with_og(&C1, *GN1);
                 let hint = quads.size_hint();
                 for iter in vec![quads, d.quads_matching(&ANY, &ANY, &*C1, &*GN1)] {
-                    let v: Vec<_> = iter.oks().map(as_box_q).collect();
+                    let v: Vec<_> = iter.map(as_box_q).collect();
                     assert_eq!(v.len(), 2);
                     assert_consistent_hint(v.len(), hint);
                     assert!(Dataset::contains(&v, &C2, &rdfs::subClassOf, &C1, *GN1)?);
@@ -570,7 +575,7 @@ macro_rules! test_dataset_impl {
                     quads,
                     d.quads_matching(&*C1, &rdf::type_, &rdfs::Class, &ANY),
                 ] {
-                    let v: Vec<_> = iter.oks().map(as_box_q).collect();
+                    let v: Vec<_> = iter.map(as_box_q).collect();
                     assert_eq!(v.len(), 2);
                     assert_consistent_hint(v.len(), hint);
                     assert!(Dataset::contains(&v, &C1, &rdf::type_, &rdfs::Class, *DG)?);
@@ -588,7 +593,7 @@ macro_rules! test_dataset_impl {
                 let quads = d.quads_with_spg(&C1, &rdf::type_, *DG);
                 let hint = quads.size_hint();
                 for iter in vec![quads, d.quads_matching(&*C1, &rdf::type_, &ANY, &*DG)] {
-                    let v: Vec<_> = iter.oks().map(as_box_q).collect();
+                    let v: Vec<_> = iter.map(as_box_q).collect();
                     assert_eq!(v.len(), 1);
                     assert_consistent_hint(v.len(), hint);
                     assert!(Dataset::contains(&v, &C1, &rdf::type_, &rdfs::Class, *DG)?);
@@ -612,7 +617,7 @@ macro_rules! test_dataset_impl {
                 let quads = d.quads_with_sog(&C1, &rdfs::Class, *DG);
                 let hint = quads.size_hint();
                 for iter in vec![quads, d.quads_matching(&*C1, &ANY, &rdfs::Class, &*DG)] {
-                    let v: Vec<_> = iter.oks().map(as_box_q).collect();
+                    let v: Vec<_> = iter.map(as_box_q).collect();
                     assert_eq!(v.len(), 1);
                     assert_consistent_hint(v.len(), hint);
                     assert!(Dataset::contains(&v, &C1, &rdf::type_, &rdfs::Class, *DG)?);
@@ -639,7 +644,7 @@ macro_rules! test_dataset_impl {
                     quads,
                     d.quads_matching(&ANY, &rdf::type_, &rdfs::Class, &*DG),
                 ] {
-                    let v: Vec<_> = iter.oks().map(as_box_q).collect();
+                    let v: Vec<_> = iter.map(as_box_q).collect();
                     assert_eq!(v.len(), 2);
                     assert_consistent_hint(v.len(), hint);
                     assert!(Dataset::contains(&v, &C2, &rdf::type_, &rdfs::Class, *DG)?);
@@ -666,7 +671,7 @@ macro_rules! test_dataset_impl {
                     quads,
                     d.quads_matching(&*C1, &rdf::type_, &rdfs::Class, &*DG),
                 ] {
-                    let v: Vec<_> = iter.oks().map(as_box_q).collect();
+                    let v: Vec<_> = iter.map(as_box_q).collect();
                     assert_eq!(v.len(), 1);
                     assert_consistent_hint(v.len(), hint);
                     assert!(Dataset::contains(&v, &C1, &rdf::type_, &rdfs::Class, *DG)?);
@@ -701,7 +706,6 @@ macro_rules! test_dataset_impl {
                 let g_matcher = |g: Option<&Term<&str>>| g.is_some();
                 let v: Vec<_> = d
                     .quads_matching(&ANY, &p_matcher[..], &o_matcher[..], &g_matcher)
-                    .oks()
                     .map(as_box_q)
                     .collect();
                 assert_eq!(v.len(), 6);

--- a/sophia/src/graph/test.rs
+++ b/sophia/src/graph/test.rs
@@ -78,7 +78,12 @@ pub fn populate_nodes_types<G: MutableGraph>(g: &mut G) -> MGResult<G, ()> {
     Ok(())
 }
 
-pub fn as_box_t<T: Triple>(triple: T) -> [BoxTerm; 3] {
+pub fn as_box_t<T: Triple, E>(triple: Result<T, E>) -> [BoxTerm; 3] {
+    let triple = match triple {
+        Ok(t) => t,
+        Err(_) => panic!("as_box_t received an error")
+    };
+
     [triple.s().into(), triple.p().into(), triple.o().into()]
 }
 
@@ -132,7 +137,6 @@ macro_rules! test_graph_impl {
     ($module_name: ident, $mutable_graph_impl: ident, $is_set: expr, $mutable_graph_factory: path) => {
         #[cfg(test)]
         mod $module_name {
-            use resiter::oks::*;
             use sophia_term::matcher::ANY;
             use sophia_term::*;
             use $crate::graph::test::*;
@@ -256,7 +260,7 @@ macro_rules! test_graph_impl {
                 let triples = g.triples();
                 let hint = triples.size_hint();
                 for iter in vec![triples, g.triples_matching(&ANY, &ANY, &ANY)] {
-                    let v: Vec<_> = iter.oks().map(as_box_t).collect();
+                    let v: Vec<_> = iter.map(as_box_t).collect();
                     assert_eq!(v.len(), g.triples().count());
                     assert_consistent_hint(v.len(), hint);
                     assert!(Graph::contains(&v, &C1, &rdf::type_, &rdfs::Class)?);
@@ -273,7 +277,7 @@ macro_rules! test_graph_impl {
                 let triples = g.triples_with_s(&C2);
                 let hint = triples.size_hint();
                 for iter in vec![triples, g.triples_matching(&*C2, &ANY, &ANY)] {
-                    let v: Vec<_> = iter.oks().map(as_box_t).collect();
+                    let v: Vec<_> = iter.map(as_box_t).collect();
                     assert_eq!(v.len(), 4);
                     assert_consistent_hint(v.len(), hint);
                     assert!(Graph::contains(&v, &C2, &rdf::type_, &rdfs::Class)?);
@@ -290,7 +294,7 @@ macro_rules! test_graph_impl {
                 let triples = g.triples_with_p(&rdf::type_);
                 let hint = triples.size_hint();
                 for iter in vec![triples, g.triples_matching(&ANY, &rdf::type_, &ANY)] {
-                    let v: Vec<_> = iter.oks().map(as_box_t).collect();
+                    let v: Vec<_> = iter.map(as_box_t).collect();
                     assert_eq!(v.len(), 9);
                     assert_consistent_hint(v.len(), hint);
                     assert!(Graph::contains(&v, &C2, &rdf::type_, &rdfs::Resource)?);
@@ -312,7 +316,7 @@ macro_rules! test_graph_impl {
                 let triples = g.triples_with_o(&C2);
                 let hint = triples.size_hint();
                 for iter in vec![triples, g.triples_matching(&ANY, &ANY, &*C2)] {
-                    let v: Vec<_> = iter.oks().map(as_box_t).collect();
+                    let v: Vec<_> = iter.map(as_box_t).collect();
                     assert_eq!(v.len(), 5);
                     assert_consistent_hint(v.len(), hint);
                     assert!(Graph::contains(&v, &P2, &rdfs::domain, &C2)?);
@@ -329,7 +333,7 @@ macro_rules! test_graph_impl {
                 let triples = g.triples_with_sp(&C2, &rdf::type_);
                 let hint = triples.size_hint();
                 for iter in vec![triples, g.triples_matching(&*C2, &rdf::type_, &ANY)] {
-                    let v: Vec<_> = iter.oks().map(as_box_t).collect();
+                    let v: Vec<_> = iter.map(as_box_t).collect();
                     assert_eq!(v.len(), 2);
                     assert_consistent_hint(v.len(), hint);
                     assert!(Graph::contains(&v, &C2, &rdf::type_, &rdfs::Class)?);
@@ -347,7 +351,7 @@ macro_rules! test_graph_impl {
                 let hint = triples.size_hint();
 
                 for iter in vec![triples, g.triples_matching(&*C2, &ANY, &rdfs::Resource)] {
-                    let v: Vec<_> = iter.oks().map(as_box_t).collect();
+                    let v: Vec<_> = iter.map(as_box_t).collect();
                     assert_eq!(v.len(), 2);
                     assert_consistent_hint(v.len(), hint);
                     assert!(Graph::contains(
@@ -369,7 +373,7 @@ macro_rules! test_graph_impl {
                 let triples = g.triples_with_po(&rdf::type_, &rdfs::Class);
                 let hint = triples.size_hint();
                 for iter in vec![triples, g.triples_matching(&ANY, &rdf::type_, &rdfs::Class)] {
-                    let v: Vec<_> = iter.oks().map(as_box_t).collect();
+                    let v: Vec<_> = iter.map(as_box_t).collect();
                     assert_eq!(v.len(), 2);
                     assert_consistent_hint(v.len(), hint);
                     assert!(Graph::contains(&v, &C2, &rdf::type_, &rdfs::Class)?);
@@ -389,7 +393,7 @@ macro_rules! test_graph_impl {
                     triples,
                     g.triples_matching(&*C2, &rdf::type_, &rdfs::Resource),
                 ] {
-                    let v: Vec<_> = iter.oks().map(as_box_t).collect();
+                    let v: Vec<_> = iter.map(as_box_t).collect();
                     assert_eq!(v.len(), 1);
                     assert_consistent_hint(v.len(), hint);
                     assert!(Graph::contains(&v, &C2, &rdf::type_, &rdfs::Resource)?);
@@ -421,7 +425,6 @@ macro_rules! test_graph_impl {
                 let o_matcher: [StaticTerm; 2] = [C2.clone(), rdfs::Class.clone()];
                 let v: Vec<_> = g
                     .triples_matching(&ANY, &p_matcher[..], &o_matcher[..])
-                    .oks()
                     .map(as_box_t)
                     .collect();
                 assert_eq!(v.len(), 5);


### PR DESCRIPTION
Currently we can not use the test macro for sophia graphs in other crates that implements this trait.

This first PR purpose is to remove the reciter dependency in tests.

- If the reciter dependency is kept, users have to include resiter in the Cargo.toml file which is not user friendly.
- Tests now panics when a result is an error instead of discarding the error because an error means the whole dataset was not properly retrieved (the test fails earlier)