### PR TITLE
Introduce `map()` and helpers to `Term` and similars

### DIFF
--- a/sophia/src/dataset/_ext_impl.rs
+++ b/sophia/src/dataset/_ext_impl.rs
@@ -56,10 +56,10 @@ impl MutableDataset for Vec<([BoxTerm; 3], Option<BoxTerm>)> {
         V: TermData,
         W: TermData,
     {
-        let s = s.into();
-        let p = p.into();
-        let o = o.into();
-        let g = g.map(|n| n.into());
+        let s = s.clone_into();
+        let p = p.clone_into();
+        let o = o.clone_into();
+        let g = g.map(|n| n.clone_into());
         self.push(([s, p, o], g));
         Ok(true)
     }
@@ -118,10 +118,10 @@ impl<S: ::std::hash::BuildHasher> MutableDataset for HashSet<([BoxTerm; 3], Opti
         V: TermData,
         W: TermData,
     {
-        let s = s.into();
-        let p = p.into();
-        let o = o.into();
-        let g = g.map(|n| n.into());
+        let s = s.clone_into();
+        let p = p.clone_into();
+        let o = o.clone_into();
+        let g = g.map(|n| n.clone_into());
         Ok(HashSet::insert(self, ([s, p, o], g)))
     }
     fn remove<T, U, V, W>(
@@ -137,10 +137,10 @@ impl<S: ::std::hash::BuildHasher> MutableDataset for HashSet<([BoxTerm; 3], Opti
         V: TermData,
         W: TermData,
     {
-        let s = s.into();
-        let p = p.into();
-        let o = o.into();
-        let g = g.map(|n| n.into());
+        let s = s.clone_into();
+        let p = p.clone_into();
+        let o = o.clone_into();
+        let g = g.map(|n| n.clone_into());
         Ok(HashSet::remove(self, &([s, p, o], g)))
     }
 }

--- a/sophia/src/dataset/_traits.rs
+++ b/sophia/src/dataset/_traits.rs
@@ -532,7 +532,7 @@ pub trait Dataset {
     {
         DatasetGraph {
             dataset: self,
-            gmatcher: graph_name.map(|n| n.into()),
+            gmatcher: graph_name.map(|n| n.clone_into()),
             _phantom: PhantomData,
         }
     }
@@ -547,7 +547,7 @@ pub trait Dataset {
     {
         DatasetGraph {
             dataset: self,
-            gmatcher: graph_name.map(|n| n.into()),
+            gmatcher: graph_name.map(|n| n.clone_into()),
             _phantom: PhantomData,
         }
     }
@@ -681,11 +681,11 @@ pub trait MutableDataset: Dataset {
             .map_ok(|q| {
                 (
                     [
-                        BoxTerm::from(q.s()),
-                        BoxTerm::from(q.p()),
-                        BoxTerm::from(q.o()),
+                        q.s().clone_into::<Box<str>>(),
+                        q.p().clone_into::<Box<str>>(),
+                        q.o().clone_into::<Box<str>>(),
                     ],
-                    q.g().map(BoxTerm::from),
+                    q.g().map(|g| g.clone_into::<Box<str>>()),
                 )
             })
             .collect::<std::result::Result<Vec<_>, _>>()
@@ -718,11 +718,11 @@ pub trait MutableDataset: Dataset {
             .map_ok(|q| {
                 (
                     [
-                        BoxTerm::from(q.s()),
-                        BoxTerm::from(q.p()),
-                        BoxTerm::from(q.o()),
+                        q.s().clone_into::<Box<str>>(),
+                        q.p().clone_into::<Box<str>>(),
+                        q.o().clone_into::<Box<str>>(),
                     ],
-                    q.g().map(BoxTerm::from),
+                    q.g().map(|g| g.clone_into::<Box<str>>()),
                 )
             })
             .collect::<std::result::Result<Vec<_>, _>>()

--- a/sophia/src/dataset/adapter.rs
+++ b/sophia/src/dataset/adapter.rs
@@ -205,7 +205,7 @@ pub(crate) mod test {
     pub fn make_named_graph() -> MyDatasetGraph {
         DatasetGraph {
             dataset: MyDataset::new(),
-            gmatcher: Some(BoxTerm::from(&rdfs::Resource)),
+            gmatcher: Some(rdfs::Resource.map_into()),
             _phantom: PhantomData,
         }
     }

--- a/sophia/src/dataset/inmem/_hash_dataset.rs
+++ b/sophia/src/dataset/inmem/_hash_dataset.rs
@@ -66,7 +66,7 @@ where
     where
         T: TermData,
     {
-        self.terms.get_index(&t.into())
+        self.terms.get_index(&t.clone_into())
     }
 
     #[inline]
@@ -75,7 +75,7 @@ where
         T: TermData,
     {
         self.terms
-            .get_index_for_graph_name(g.map(RefTerm::from).as_ref())
+            .get_index_for_graph_name(g.map(|g| g.as_ref_str()).as_ref())
     }
 
     #[inline]
@@ -101,12 +101,12 @@ where
         V: TermData,
         W: TermData,
     {
-        let si = self.terms.make_index(&s.into());
-        let pi = self.terms.make_index(&p.into());
-        let oi = self.terms.make_index(&o.into());
+        let si = self.terms.make_index(&s.clone_into());
+        let pi = self.terms.make_index(&p.clone_into());
+        let oi = self.terms.make_index(&o.clone_into());
         let gi = self
             .terms
-            .make_index_for_graph_name(g.map(RefTerm::from).as_ref());
+            .make_index_for_graph_name(g.map(|g| g.as_ref_str()).as_ref());
         let modified = self.quads.insert([si, pi, oi, gi]);
         if modified {
             Some([si, pi, oi, gi])

--- a/sophia/src/dataset/test.rs
+++ b/sophia/src/dataset/test.rs
@@ -56,12 +56,7 @@ pub fn populate<D: MutableDataset>(d: &mut D) -> MDResult<D, ()> {
 }
 
 pub fn populate_nodes_types<D: MutableDataset>(d: &mut D) -> MDResult<D, ()> {
-    d.insert(
-        &rdf::type_,
-        &rdf::type_,
-        &rdf::Property,
-        Some(StaticTerm::from(&rdf::type_)).as_ref(),
-    )?;
+    d.insert(&rdf::type_, &rdf::type_, &rdf::Property, Some(&rdf::type_))?;
     d.insert(
         &StaticTerm::new_bnode("b1").unwrap(),
         &StaticTerm::new_bnode("b2").unwrap(),
@@ -98,8 +93,12 @@ pub fn as_box_q<Q: Quad, E>(quad: Result<Q, E>) -> ([BoxTerm; 3], Option<BoxTerm
     };
 
     (
-        [quad.s().into(), quad.p().into(), quad.o().into()],
-        quad.g().map(|n| n.into()),
+        [
+            quad.s().clone_into(),
+            quad.p().clone_into(),
+            quad.o().clone_into(),
+        ],
+        quad.g().map(|n| n.clone_into()),
     )
 }
 
@@ -733,7 +732,7 @@ macro_rules! test_dataset_impl {
                 assert_eq!(subjects.len(), 8);
 
                 let rsubjects: std::collections::HashSet<_> =
-                    subjects.iter().map(|t| RefTerm::from(t)).collect();
+                    subjects.iter().map(|t| t.as_ref_str()).collect();
                 assert!(rsubjects.contains(&C1));
                 assert!(rsubjects.contains(&C2));
                 assert!(rsubjects.contains(&P1));
@@ -754,7 +753,7 @@ macro_rules! test_dataset_impl {
                 assert_eq!(predicates.len(), 6);
 
                 let rpredicates: std::collections::HashSet<_> =
-                    predicates.iter().map(|t| RefTerm::from(t)).collect();
+                    predicates.iter().map(|t| t.as_ref_str()).collect();
                 assert!(rpredicates.contains(&rdf::type_));
                 assert!(rpredicates.contains(&rdfs::subClassOf));
                 assert!(rpredicates.contains(&rdfs::domain));
@@ -773,7 +772,7 @@ macro_rules! test_dataset_impl {
                 assert_eq!(objects.len(), 6);
 
                 let robjects: std::collections::HashSet<_> =
-                    objects.iter().map(|t| RefTerm::from(t)).collect();
+                    objects.iter().map(|t| t.as_ref_str()).collect();
                 assert!(robjects.contains(&rdf::Property));
                 assert!(robjects.contains(&rdfs::Class));
                 assert!(robjects.contains(&C1));
@@ -792,7 +791,7 @@ macro_rules! test_dataset_impl {
                 assert_eq!(graph_names.len(), 2);
 
                 let rgraph_names: std::collections::HashSet<_> =
-                    graph_names.iter().map(|t| RefTerm::from(t)).collect();
+                    graph_names.iter().map(|t| t.as_ref_str()).collect();
                 assert!(rgraph_names.contains(&G1));
                 assert!(rgraph_names.contains(&G2));
                 Ok(())
@@ -807,7 +806,7 @@ macro_rules! test_dataset_impl {
                 assert_eq!(iris.len(), 2);
 
                 let riris: std::collections::HashSet<_> =
-                    iris.iter().map(|t| RefTerm::from(t)).collect();
+                    iris.iter().map(|t| t.as_ref_str()).collect();
                 assert!(riris.contains(&rdf::Property));
                 assert!(riris.contains(&rdf::type_));
                 Ok(())
@@ -837,7 +836,7 @@ macro_rules! test_dataset_impl {
                 assert_eq!(literals.len(), 3);
 
                 let rliterals: std::collections::HashSet<_> =
-                    literals.iter().map(|t| RefTerm::from(t)).collect();
+                    literals.iter().map(|t| t.as_ref_str()).collect();
                 assert!(rliterals.contains(&StaticTerm::from("lit1")));
                 assert!(rliterals.contains(&StaticTerm::from("lit2")));
                 assert!(rliterals.contains(&StaticTerm::new_literal_lang("lit2", "en").unwrap()));

--- a/sophia/src/graph/_ext_impl.rs
+++ b/sophia/src/graph/_ext_impl.rs
@@ -56,9 +56,9 @@ impl MutableGraph for Vec<[BoxTerm; 3]> {
         U: TermData,
         V: TermData,
     {
-        let s = BoxTerm::from(s);
-        let p = BoxTerm::from(p);
-        let o = BoxTerm::from(o);
+        let s = s.clone_into();
+        let p = p.clone_into();
+        let o = o.clone_into();
         self.push([s, p, o]);
         Ok(true)
     }
@@ -107,9 +107,9 @@ where
         U: TermData,
         V: TermData,
     {
-        let s = BoxTerm::from(s);
-        let p = BoxTerm::from(p);
-        let o = BoxTerm::from(o);
+        let s = s.clone_into();
+        let p = p.clone_into();
+        let o = o.clone_into();
         Ok(HashSet::insert(self, [s, p, o]))
     }
     fn remove<T, U, V>(&mut self, s: &Term<T>, p: &Term<U>, o: &Term<V>) -> MGResult<Self, bool>
@@ -118,9 +118,9 @@ where
         U: TermData,
         V: TermData,
     {
-        let s = BoxTerm::from(s);
-        let p = BoxTerm::from(p);
-        let o = BoxTerm::from(o);
+        let s = s.clone_into();
+        let p = p.clone_into();
+        let o = o.clone_into();
         Ok(HashSet::remove(self, &[s, p, o]))
     }
 }

--- a/sophia/src/graph/_traits.rs
+++ b/sophia/src/graph/_traits.rs
@@ -491,9 +491,9 @@ pub trait MutableGraph: Graph {
             .triples_matching(ms, mp, mo)
             .map_ok(|t| {
                 [
-                    BoxTerm::from(t.s()),
-                    BoxTerm::from(t.p()),
-                    BoxTerm::from(t.o()),
+                    t.s().clone_into::<Box<str>>(),
+                    t.p().clone_into::<Box<str>>(),
+                    t.o().clone_into::<Box<str>>(),
                 ]
             })
             .collect::<std::result::Result<Vec<_>, _>>()
@@ -527,9 +527,9 @@ pub trait MutableGraph: Graph {
             .filter_ok(|t| !(ms.matches(t.s()) && mp.matches(t.p()) && mo.matches(t.o())))
             .map_ok(|t| {
                 [
-                    BoxTerm::from(t.s()),
-                    BoxTerm::from(t.p()),
-                    BoxTerm::from(t.o()),
+                    t.s().clone_into::<Box<str>>(),
+                    t.p().clone_into::<Box<str>>(),
+                    t.o().clone_into::<Box<str>>(),
                 ]
             })
             .collect::<std::result::Result<Vec<_>, _>>()

--- a/sophia/src/graph/inmem.rs
+++ b/sophia/src/graph/inmem.rs
@@ -6,7 +6,7 @@
 //!
 //! It also provides two pre-defined trade-offs:
 //! [`FastGraph`] and [`LightGraph`],
-//! provided in different flavours
+//! provided in different flavors
 //! ([default](#types), [`small`](small/index.html), [`sync`](sync/index.html)).
 //!
 //! # Customized trade-off
@@ -74,7 +74,7 @@ test_graph_impl!(test_fastg, FastGraph);
 #[cfg(test)]
 test_graph_impl!(test_lightg, LightGraph);
 
-/// Flavours of Graph implementations with a smaller memory-footprint.
+/// Flavors of Graph implementations with a smaller memory-footprint.
 ///
 /// The trade-off is that these implementations can only contain a small number (2^16) of terms.
 ///
@@ -94,7 +94,7 @@ pub mod small {
     test_graph_impl!(test_lightg, LightGraph);
 }
 
-/// Flavours of Graph implementations which are safe to share across threads.
+/// Flavors of Graph implementations which are safe to share across threads.
 pub mod sync {
     use super::*;
 

--- a/sophia/src/graph/inmem/_hash_graph.rs
+++ b/sophia/src/graph/inmem/_hash_graph.rs
@@ -9,7 +9,7 @@ use crate::graph::*;
 use crate::triple::streaming_mode::{ByTermRefs, StreamedTriple};
 use sophia_term::factory::TermFactory;
 use sophia_term::index_map::TermIndexMap;
-use sophia_term::{RefTerm, Term, TermData};
+use sophia_term::{Term, TermData};
 
 /// A generic implementation of [`Graph`] and [`MutableGraph`],
 /// storing its terms in a [`TermIndexMap`],
@@ -65,7 +65,7 @@ where
     where
         T: TermData,
     {
-        self.terms.get_index(&RefTerm::from(t))
+        self.terms.get_index(&t.as_ref_str())
     }
 
     #[inline]
@@ -84,9 +84,9 @@ where
         U: TermData,
         V: TermData,
     {
-        let si = self.terms.make_index(&RefTerm::from(s));
-        let pi = self.terms.make_index(&RefTerm::from(p));
-        let oi = self.terms.make_index(&RefTerm::from(o));
+        let si = self.terms.make_index(&s.as_ref_str());
+        let pi = self.terms.make_index(&p.as_ref_str());
+        let oi = self.terms.make_index(&o.as_ref_str());
         let modified = self.triples.insert([si, pi, oi]);
         if modified {
             Some([si, pi, oi])
@@ -109,9 +109,9 @@ where
         U: TermData,
         V: TermData,
     {
-        let si = self.terms.get_index(&RefTerm::from(s));
-        let pi = self.terms.get_index(&RefTerm::from(p));
-        let oi = self.terms.get_index(&RefTerm::from(o));
+        let si = self.terms.get_index(&s.as_ref_str());
+        let pi = self.terms.get_index(&p.as_ref_str());
+        let oi = self.terms.get_index(&o.as_ref_str());
         if let (Some(si), Some(pi), Some(oi)) = (si, pi, oi) {
             let modified = self.triples.remove(&[si, pi, oi]);
             if modified {

--- a/sophia/src/graph/inmem/_term_index_map_u.rs
+++ b/sophia/src/graph/inmem/_term_index_map_u.rs
@@ -215,7 +215,7 @@ where
     S: TermData,
     T: Borrow<Term<S>>,
 {
-    t.borrow().clone_with(|txt| &*(txt as *const str))
+    t.borrow().clone_map(|txt| &*(txt as *const str))
 }
 
 #[cfg(test)]

--- a/sophia/src/graph/test.rs
+++ b/sophia/src/graph/test.rs
@@ -84,7 +84,11 @@ pub fn as_box_t<T: Triple, E>(triple: Result<T, E>) -> [BoxTerm; 3] {
         Err(_) => panic!("as_box_t received an error"),
     };
 
-    [triple.s().into(), triple.p().into(), triple.o().into()]
+    [
+        triple.s().clone_into(),
+        triple.p().clone_into(),
+        triple.o().clone_into(),
+    ]
 }
 
 #[allow(dead_code)]
@@ -446,7 +450,7 @@ macro_rules! test_graph_impl {
                 assert_eq!(subjects.len(), 8);
 
                 let rsubjects: std::collections::HashSet<_> =
-                    subjects.iter().map(|t| RefTerm::from(t)).collect();
+                    subjects.iter().map(|t| t.as_ref_str()).collect();
                 assert!(rsubjects.contains(&C1));
                 assert!(rsubjects.contains(&C2));
                 assert!(rsubjects.contains(&P1));
@@ -467,7 +471,7 @@ macro_rules! test_graph_impl {
                 assert_eq!(predicates.len(), 6);
 
                 let rpredicates: std::collections::HashSet<_> =
-                    predicates.iter().map(|t| RefTerm::from(t)).collect();
+                    predicates.iter().map(|t| t.as_ref_str()).collect();
                 assert!(rpredicates.contains(&rdf::type_));
                 assert!(rpredicates.contains(&rdfs::subClassOf));
                 assert!(rpredicates.contains(&rdfs::domain));
@@ -486,7 +490,7 @@ macro_rules! test_graph_impl {
                 assert_eq!(objects.len(), 7);
 
                 let robjects: std::collections::HashSet<_> =
-                    objects.iter().map(|t| RefTerm::from(t)).collect();
+                    objects.iter().map(|t| t.as_ref_str()).collect();
                 assert!(robjects.contains(&rdf::Property));
                 assert!(robjects.contains(&rdfs::Class));
                 assert!(robjects.contains(&rdfs::Resource));
@@ -506,7 +510,7 @@ macro_rules! test_graph_impl {
                 assert_eq!(iris.len(), 2);
 
                 let riris: std::collections::HashSet<_> =
-                    iris.iter().map(|t| RefTerm::from(t)).collect();
+                    iris.iter().map(|t| t.as_ref_str()).collect();
                 assert!(riris.contains(&rdf::Property));
                 assert!(riris.contains(&rdf::type_));
                 Ok(())
@@ -536,7 +540,7 @@ macro_rules! test_graph_impl {
                 assert_eq!(literals.len(), 3);
 
                 let rliterals: std::collections::HashSet<_> =
-                    literals.iter().map(|t| RefTerm::from(t)).collect();
+                    literals.iter().map(|t| t.as_ref_str()).collect();
                 assert!(rliterals.contains(&StaticTerm::from("lit1")));
                 assert!(rliterals.contains(&StaticTerm::from("lit2")));
                 assert!(rliterals.contains(&StaticTerm::new_literal_lang("lit2", "en").unwrap()));

--- a/sophia/src/parser/rio_common.rs
+++ b/sophia/src/parser/rio_common.rs
@@ -217,5 +217,5 @@ pub fn rio2refterm(t: GeneralizedTerm) -> RefTerm {
 
 /// Convert RIO term to Sophia term
 pub fn rio2boxterm(t: GeneralizedTerm) -> BoxTerm {
-    rio2refterm(t).clone_with(Box::from)
+    rio2refterm(t).map_into()
 }

--- a/sophia/src/parser/xml.rs
+++ b/sophia/src/parser/xml.rs
@@ -348,7 +348,7 @@ mod test {
 
                 fn relabel(factory: &mut RcTermFactory, t: Term<Rc<str>>) -> Term<Rc<str>> {
                     if let Term::BNode(bnode) = t {
-                        match bnode.as_ref() {
+                        match bnode.as_str() {
                             $($l => factory.bnode($r).unwrap(),)*
                             other => factory.bnode(other).unwrap(),
                         }

--- a/sophia/src/quad/stream/test.rs
+++ b/sophia/src/quad/stream/test.rs
@@ -153,7 +153,7 @@ fn filter_map_quads_to_triples() {
     d.quads()
         .filter_map_quads(|q| -> Option<[BoxTerm; 3]> {
             if q.s() == &BOB as &StaticTerm {
-                Some([q.s().into(), q.p().into(), q.o().into()])
+                Some([q.s().clone_into(), q.p().clone_into(), q.o().clone_into()])
             } else {
                 None
             }
@@ -219,7 +219,9 @@ fn map_quads_to_triple() {
     let d = make_dataset();
     let mut g = Vec::<[BoxTerm; 3]>::new();
     d.quads()
-        .map_quads(|q| -> [BoxTerm; 3] { [q.s().into(), q.p().into(), q.o().into()] })
+        .map_quads(|q| -> [BoxTerm; 3] {
+            [q.s().clone_into(), q.p().clone_into(), q.o().clone_into()]
+        })
         .in_graph(&mut g)
         .unwrap();
     assert_eq!(d.len(), g.len());

--- a/sophia/src/query.rs
+++ b/sophia/src/query.rs
@@ -133,7 +133,7 @@ where
 /// Make a matcher corresponding to term `t`, given binding `b`.
 fn matcher(t: &RcTerm, b: &BindingMap) -> Binding {
     if let Term::Variable(var) = t {
-        let vname: &str = var.as_ref();
+        let vname: &str = var.as_str();
         b.get(vname).cloned().into()
     } else {
         Binding::Exactly(t.clone())

--- a/sophia/src/query.rs
+++ b/sophia/src/query.rs
@@ -118,13 +118,13 @@ where
     triples_matching(g, unsafe { &*(&tm[..] as *const [Binding]) }).map_ok(move |tr| {
         let mut b2 = b.clone();
         if tm[0].is_free() {
-            b2.insert(tq.s().value().to_string(), tr.s().into());
+            b2.insert(tq.s().value().to_string(), tr.s().clone_into());
         }
         if tm[1].is_free() {
-            b2.insert(tq.p().value().to_string(), tr.p().into());
+            b2.insert(tq.p().value().to_string(), tr.p().clone_into());
         }
         if tm[2].is_free() {
-            b2.insert(tq.o().value().to_string(), tr.o().into());
+            b2.insert(tq.o().value().to_string(), tr.o().clone_into());
         }
         b2
     })
@@ -183,11 +183,7 @@ mod test {
         let s_event = schema.get("Event").unwrap();
         let x_alice = RcTerm::new_iri("http://example.org/alice").unwrap();
 
-        let tq: [RcTerm; 3] = [
-            x_alice.clone(),
-            RcTerm::from(&rdf::type_),
-            RcTerm::from(&s_event),
-        ];
+        let tq: [RcTerm; 3] = [x_alice.clone(), rdf::type_.map_into(), s_event.map_into()];
 
         let results: Result<Vec<_>, _> = bindings_for_triple(&g, &tq, BindingMap::new()).collect();
         let results = results.unwrap();
@@ -202,11 +198,7 @@ mod test {
         let s_person = schema.get("Person").unwrap();
         let x_alice = RcTerm::new_iri("http://example.org/alice").unwrap();
 
-        let tq: [RcTerm; 3] = [
-            x_alice.clone(),
-            RcTerm::from(&rdf::type_),
-            RcTerm::from(&s_person),
-        ];
+        let tq: [RcTerm; 3] = [x_alice.clone(), rdf::type_.map_into(), s_person.map_into()];
 
         let results: Result<Vec<BindingMap>, _> =
             bindings_for_triple(&g, &tq, BindingMap::new()).collect();
@@ -226,11 +218,7 @@ mod test {
 
         let v1 = RcTerm::new_variable("v1").unwrap();
 
-        let tq: [RcTerm; 3] = [
-            v1.clone(),
-            RcTerm::from(&rdf::type_),
-            RcTerm::from(&s_event),
-        ];
+        let tq: [RcTerm; 3] = [v1.clone(), rdf::type_.map_into(), s_event.map_into()];
 
         let results: Result<Vec<BindingMap>, _> =
             bindings_for_triple(&g, &tq, BindingMap::new()).collect();
@@ -247,11 +235,7 @@ mod test {
 
         let v1 = RcTerm::new_variable("v1").unwrap();
 
-        let tq: [RcTerm; 3] = [
-            v1.clone(),
-            RcTerm::from(&rdf::type_),
-            RcTerm::from(&s_person),
-        ];
+        let tq: [RcTerm; 3] = [v1.clone(), rdf::type_.map_into(), s_person.map_into()];
 
         let results: Result<Vec<BindingMap>, _> =
             bindings_for_triple(&g, &tq, BindingMap::new()).collect();
@@ -281,7 +265,7 @@ mod test {
         let v1 = RcTerm::new_variable("v1").unwrap();
         let v2 = RcTerm::new_variable("v2").unwrap();
 
-        let tq: [RcTerm; 3] = [v1.clone(), RcTerm::from(&s_name), v2.clone()];
+        let tq: [RcTerm; 3] = [v1.clone(), s_name.map_into(), v2.clone()];
 
         let results: Result<Vec<BindingMap>, _> =
             bindings_for_triple(&g, &tq, BindingMap::new()).collect();
@@ -322,12 +306,8 @@ mod test {
         let v2 = RcTerm::new_variable("v2").unwrap();
 
         let mut q = Query::Triples(vec![
-            [v1.clone(), RcTerm::from(&s_name), v2.clone()],
-            [
-                v1.clone(),
-                RcTerm::from(&rdf::type_),
-                RcTerm::from(&s_person),
-            ],
+            [v1.clone(), s_name.map_into(), v2.clone()],
+            [v1.clone(), rdf::type_.map_into(), s_person.map_into()],
         ]);
 
         let results: Result<Vec<BindingMap>, _> = q.process(&g).collect();

--- a/sophia/src/triple/stream/test.rs
+++ b/sophia/src/triple/stream/test.rs
@@ -151,7 +151,12 @@ fn filter_map_triples_to_quads() {
     g.triples()
         .filter_map_triples(|t| -> Option<[BoxTerm; 4]> {
             if t.s() == &BOB as &StaticTerm {
-                Some([t.s().into(), t.p().into(), t.o().into(), t.s().into()])
+                Some([
+                    t.s().clone_into(),
+                    t.p().clone_into(),
+                    t.o().clone_into(),
+                    t.s().clone_into(),
+                ])
             } else {
                 None
             }
@@ -213,7 +218,12 @@ fn map_triples_to_quads() {
     let mut d = Vec::<([BoxTerm; 3], Option<BoxTerm>)>::new();
     g.triples()
         .map_triples(|t| -> [BoxTerm; 4] {
-            [t.s().into(), t.p().into(), t.o().into(), t.s().into()]
+            [
+                t.s().clone_into(),
+                t.p().clone_into(),
+                t.o().clone_into(),
+                t.s().clone_into(),
+            ]
         })
         .in_dataset(&mut d)
         .unwrap();

--- a/term/src/_graph_name_matcher.rs
+++ b/term/src/_graph_name_matcher.rs
@@ -209,7 +209,7 @@ impl<F: Fn(Option<&Term<&str>>) -> bool> GraphNameMatcher for F {
     where
         T: TermData,
     {
-        (self)(g.map(RefTerm::from).as_ref())
+        (self)(g.map(|t| t.as_ref_str()).as_ref())
     }
 }
 

--- a/term/src/blank_node.rs
+++ b/term/src/blank_node.rs
@@ -328,5 +328,39 @@ mod test {
         }
     }
 
+    #[test]
+    fn map() {
+        let input: BlankNode<&str> = BlankNode::new("test").unwrap();
+        let expect: BlankNode<&str> = BlankNode::new("TEST").unwrap();
+
+        let mut cnt = 0;
+        let mut invoked = 0;
+
+        let cl = input.clone_map(|s: &str| {
+            cnt += s.len();
+            invoked += 1;
+            s.to_ascii_uppercase()
+        });
+        assert_eq!(cl, expect);
+        assert_eq!(cnt, "test".len());
+        assert_eq!(invoked, 1);
+
+        cnt = 0;
+        invoked = 0;
+        let mapped = input.map(|s: &str| {
+            cnt += s.len();
+            invoked += 1;
+            s.to_ascii_uppercase()
+        });
+        assert_eq!(mapped, expect);
+        assert_eq!(cnt, "test".len());
+        assert_eq!(invoked, 1);
+
+        assert_eq!(
+            cl.map_into::<Box<str>>(),
+            mapped.clone_into::<std::sync::Arc<str>>()
+        );
+    }
+
     // further tests are executed in `crate::test`
 }

--- a/term/src/blank_node.rs
+++ b/term/src/blank_node.rs
@@ -155,7 +155,7 @@ where
     }
 
     /// Borrow the blank nodes ID.
-    /// 
+    ///
     /// _Note:_ The ID does not have a leading `_:`.
     pub fn as_str(&self) -> &str {
         self.0.as_ref()

--- a/term/src/blank_node.rs
+++ b/term/src/blank_node.rs
@@ -104,17 +104,61 @@ where
         BlankNode(id.into())
     }
 
-    /// Copy self while transforming the inner `TermData` with the given
+    /// Borrow the inner contents of the blank node.
+    pub fn as_ref(&self) -> BlankNode<&TD> {
+        BlankNode(&self.0)
+    }
+
+    /// Borrow the inner contents of the blank node as `&str`.
+    pub fn as_ref_str(&self) -> BlankNode<&str> {
+        BlankNode(self.0.as_ref())
+    }
+
+    /// Create a new blank node by applying `f` to the `TermData` of `self`.
+    pub fn map<F, TD2>(self, f: F) -> BlankNode<TD2>
+    where
+        F: FnMut(TD) -> TD2,
+        TD2: TermData,
+    {
+        let mut f = f;
+        BlankNode(f(self.0))
+    }
+
+    /// Maps the blank node using the `Into` trait.
+    pub fn map_into<TD2>(self) -> BlankNode<TD2>
+    where
+        TD: Into<TD2>,
+        TD2: TermData,
+    {
+        self.map(Into::into)
+    }
+
+    /// Clone self while transforming the inner `TermData` with the given
     /// factory.
     ///
-    /// Clone as this might allocate a new `TermData`. However there is also
-    /// `TermData` that is cheap to clone, i.e. `Copy`.
-    pub fn clone_with<'a, U, F>(&'a self, mut factory: F) -> BlankNode<U>
+    /// This is done in one step in contrast to calling `clone().map(factory)`.
+    pub fn clone_map<'a, U, F>(&'a self, factory: F) -> BlankNode<U>
     where
         U: TermData,
         F: FnMut(&'a str) -> U,
     {
-        BlankNode(factory(self.as_ref()))
+        let mut factory = factory;
+        BlankNode(factory(self.0.as_ref()))
+    }
+
+    /// Apply `clone_map()` using the `Into` trait.
+    pub fn clone_into<'src, U>(&'src self) -> BlankNode<U>
+    where
+        U: TermData + From<&'src str>,
+    {
+        self.clone_map(Into::into)
+    }
+
+    /// Borrow the blank nodes ID.
+    /// 
+    /// _Note:_ The ID does not have a leading `_:`.
+    pub fn as_str(&self) -> &str {
+        self.0.as_ref()
     }
 
     /// Writes the blank node to the `fmt::Write` using the N3 syntax.
@@ -123,7 +167,7 @@ where
         W: fmt::Write,
     {
         w.write_str("_:")?;
-        w.write_str(self.as_ref())
+        w.write_str(self.as_str())
     }
 
     /// Writes the blank node to the `io::Write` using the N3 syntax.
@@ -132,12 +176,12 @@ where
         W: io::Write,
     {
         w.write_all(b"_:")?;
-        w.write_all(self.as_ref().as_bytes())
+        w.write_all(self.as_str().as_bytes())
     }
 
     /// Return this blank nodes's identifier as text.
     pub fn value(&self) -> MownStr {
-        self.as_ref().into()
+        self.as_str().into()
     }
 }
 
@@ -147,15 +191,6 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.write_fmt(f)
-    }
-}
-
-impl<TD> AsRef<str> for BlankNode<TD>
-where
-    TD: TermData,
-{
-    fn as_ref(&self) -> &str {
-        self.0.as_ref()
     }
 }
 
@@ -176,7 +211,7 @@ where
     U: TermData,
 {
     fn eq(&self, other: &BlankNode<U>) -> bool {
-        self.as_ref() == other.as_ref()
+        self.as_str() == other.as_str()
     }
 }
 
@@ -185,7 +220,7 @@ where
     TD: TermData,
 {
     fn eq(&self, other: &str) -> bool {
-        self.as_ref() == other
+        self.as_str() == other
     }
 }
 
@@ -200,16 +235,6 @@ where
         } else {
             false
         }
-    }
-}
-
-impl<'a, T, U> From<&'a BlankNode<U>> for BlankNode<T>
-where
-    T: TermData + From<&'a str>,
-    U: TermData,
-{
-    fn from(other: &'a BlankNode<U>) -> Self {
-        other.clone_with(T::from)
     }
 }
 
@@ -239,7 +264,7 @@ where
 
     fn try_from(term: &'a Term<U>) -> Result<Self, Self::Error> {
         match term {
-            Term::BNode(bn) => Ok(bn.clone_with(T::from)),
+            Term::BNode(bn) => Ok(bn.clone_into()),
             _ => Err(TermError::UnexpectedKindOfTerm {
                 term: term.to_string(),
                 expect: "blank node".to_owned(),

--- a/term/src/factory.rs
+++ b/term/src/factory.rs
@@ -90,7 +90,7 @@ pub trait TermFactory {
     where
         T: TermData,
     {
-        other.clone_with(|txt| self.get_term_data(txt))
+        other.clone_map(|txt| self.get_term_data(txt))
     }
 
     /// Clones the given term.

--- a/term/src/iri.rs
+++ b/term/src/iri.rs
@@ -295,14 +295,26 @@ where
     /// Clone self while transforming the inner `TermData` with the given
     /// factory.
     ///
-    /// Clone as this might allocate a new `TermData`. However there is also
-    /// `TermData` that is cheap to clone, i.e. `Copy`.
-    pub fn clone_with<'a, U, F>(&'a self, factory: F) -> Iri<U>
+    /// This is done in one step in contrast to calling `clone().map(factory)`.
+    pub fn clone_map<'a, U, F>(&'a self, factory: F) -> Iri<U>
     where
         U: TermData,
         F: FnMut(&'a str) -> U,
     {
-        self.as_ref_str().map(factory)
+        let mut factory = factory;
+        Iri {
+            ns: factory(self.ns.as_ref()),
+            suffix: self.suffix.as_ref().map(|td| factory(td.as_ref())),
+            absolute: self.absolute,
+        }
+    }
+
+    /// Apply `clone_map()` using the `Into` trait.
+    pub fn clone_into<'src, U>(&'src self) -> Iri<U>
+    where
+        U: TermData + From<&'src str>,
+    {
+        self.clone_map(Into::into)
     }
 
     /// Transforms the IRI according to the given policy.
@@ -336,7 +348,7 @@ where
                 let mut factory = factory;
                 Iri::new_unchecked(factory(&full), self.absolute)
             }
-            None => self.clone_with(factory),
+            None => self.clone_map(factory),
         }
     }
 
@@ -370,7 +382,7 @@ where
                     }
                 } else if ns.ends_with(GEN_DELIMS) {
                     // case: ns does end with separator
-                    self.clone_with(factory)
+                    self.clone_map(factory)
                 } else if let Some(pos) = ns.rfind(GEN_DELIMS) {
                     // case: ns does not end with separator but contains one
                     let mut new_suffix = String::with_capacity(ns.len() - pos - 1 + suf.len());
@@ -398,7 +410,7 @@ where
                     }
                     None => {
                         // case: no separators
-                        self.clone_with(factory)
+                        self.clone_map(factory)
                     }
                 }
             }
@@ -615,7 +627,7 @@ where
 
     fn try_from(term: &'a Term<U>) -> Result<Self, Self::Error> {
         match term {
-            Term::Iri(iri) => Ok(iri.clone_with(T::from)),
+            Term::Iri(iri) => Ok(iri.clone_map(T::from)),
             _ => Err(TermError::UnexpectedKindOfTerm {
                 term: term.to_string(),
                 expect: "IRI".to_owned(),
@@ -679,7 +691,7 @@ mod test {
     fn convert_to_mown_does_not_allocate() {
         use crate::mown_str::MownStr;
         let iri1 = Iri::<Box<str>>::new_suffixed("http://example.org/", "foo").unwrap();
-        let iri2 = Iri::<MownStr>::from(&iri1);
+        let iri2 = iri1.clone_map(Into::into);
         let Iri { ns, suffix, .. } = iri2;
         if let MownStr::Own(_) = ns {
             assert!(false, "ns has been allocated");

--- a/term/src/iri.rs
+++ b/term/src/iri.rs
@@ -657,6 +657,40 @@ mod test {
     }
 
     #[test]
+    fn map() {
+        let input = Iri::new_suffixed("some/iri/", "example").unwrap();
+        let expect: Iri<&str> = Iri::new("SOME/IRI/EXAMPLE").unwrap();
+
+        let mut cnt = 0;
+        let mut invoked = 0;
+
+        let cl = input.clone_map(|s: &str| {
+            cnt += s.len();
+            invoked += 1;
+            s.to_ascii_uppercase()
+        });
+        assert_eq!(cl, expect);
+        assert_eq!(cnt, "some/iri/example".len());
+        assert_eq!(invoked, 2);
+
+        cnt = 0;
+        invoked = 0;
+        let mapped = input.map(|s: &str| {
+            cnt += s.len();
+            invoked += 1;
+            s.to_ascii_uppercase()
+        });
+        assert_eq!(mapped, expect);
+        assert_eq!(cnt, "some/iri/example".len());
+        assert_eq!(invoked, 2);
+
+        assert_eq!(
+            cl.map_into::<Box<str>>(),
+            mapped.clone_into::<std::sync::Arc<str>>()
+        );
+    }
+
+    #[test]
     fn display() {
         let iri = Iri::<&'static str>::new_suffixed("foo#", "bar").unwrap();
         assert!(!iri.is_absolute());

--- a/term/src/iri/_join.rs
+++ b/term/src/iri/_join.rs
@@ -169,17 +169,11 @@ where
             let no_suffix = other.clone_no_suffix(|s| TD2::from(s));
             let parsed = no_suffix.parse_components().expect("ensured by no_suffix");
             let joined = self.join(&parsed);
-            Iri::new_unchecked(
-                joined.to_string().as_str(),
-                joined.is_absolute(),
-            )
+            Iri::new_unchecked(joined.to_string().as_str(), joined.is_absolute())
         } else {
             let parsed = other.parse_components().expect("is not suffixed");
             let joined = self.join(&parsed);
-            Iri::new_unchecked(
-                joined.to_string().as_str(),
-                joined.is_absolute(),
-            )
+            Iri::new_unchecked(joined.to_string().as_str(), joined.is_absolute())
         }
     }
 }
@@ -204,10 +198,7 @@ where
         if other.is_absolute() {
             other.into()
         } else {
-            Literal::new_dt(
-                other.txt().as_ref(),
-                self.resolve(&other.dt()),
-            )
+            Literal::new_dt(other.txt().as_ref(), self.resolve(&other.dt()))
         }
     }
 }

--- a/term/src/iri/_join.rs
+++ b/term/src/iri/_join.rs
@@ -264,7 +264,7 @@ where
         match other {
             Term::Iri(iri) => Resolve::<_, Iri<TD2>>::resolve(self, iri).into(),
             Term::Literal(lit) => Resolve::<_, Literal<TD2>>::resolve(self, lit).into(),
-            term => term.into(),
+            term => term.clone_into(),
         }
     }
 }
@@ -282,7 +282,7 @@ where
         match other {
             Term::Iri(iri) => Resolve::<_, Iri<MownStr>>::resolve(self, iri).into(),
             Term::Literal(lit) => Resolve::<_, Literal<MownStr>>::resolve(self, lit).into(),
-            term => term.into(),
+            term => term.clone_into(),
         }
     }
 }

--- a/term/src/iri/_join.rs
+++ b/term/src/iri/_join.rs
@@ -185,7 +185,7 @@ where
     fn resolve(&self, other: &'a Iri<TD>) -> Iri<MownStr<'a>> {
         //pub fn resolve_mown<'b, TD: TermData>(&self, other: &Iri<TD>) -> Iri<MownStr<'b>> {
         if other.absolute {
-            return other.into();
+            return other.clone_into();
         }
         let mut buffer = String::new();
         let parsed = other.parse_components(&mut buffer);
@@ -204,7 +204,7 @@ where
     /// # Exception
     ///
     /// This only changes on `Typed` literals.
-    /// Language-tagged literals are absolue by construction.
+    /// Language-tagged literals are absolute by construction.
     /// Therefore, those are not affected.
     ///
     /// # Performance
@@ -229,7 +229,7 @@ where
     /// # Exception
     ///
     /// This only changes on `Typed` literals.
-    /// Language-tagged literals are absolue by construction.
+    /// Language-tagged literals are absolute by construction.
     /// Therefore, those are not affected.
     ///
     /// # Performance

--- a/term/src/iri/_join.rs
+++ b/term/src/iri/_join.rs
@@ -212,7 +212,7 @@ where
     /// May allocate an intermediate IRI if `other.dt()` is suffixed.
     fn resolve(&self, other: &'a Literal<TD>) -> Literal<TD2> {
         if other.is_absolute() {
-            other.into()
+            other.clone_into()
         } else {
             let dt: Iri<TD2> = self.resolve(&other.dt());
             Literal::new_dt(other.txt().as_ref(), dt)
@@ -237,7 +237,7 @@ where
     /// May allocate an intermediate IRI if `other.dt()` is suffixed.
     fn resolve(&self, other: &'a Literal<TD>) -> Literal<MownStr<'a>> {
         if other.is_absolute() {
-            other.into()
+            other.clone_into()
         } else {
             let dt = Iri::<MownStr>::new_unchecked(
                 self.resolve(other.dt().value().as_ref())

--- a/term/src/lib.rs
+++ b/term/src/lib.rs
@@ -218,7 +218,7 @@ where
         match self {
             Iri(iri) => iri.clone_map(factory).into(),
             BNode(bn) => bn.clone_with(factory).into(),
-            Literal(lit) => lit.clone_with(factory).into(),
+            Literal(lit) => lit.clone_map(factory).into(),
             Variable(var) => var.clone_with(factory).into(),
         }
     }

--- a/term/src/lib.rs
+++ b/term/src/lib.rs
@@ -216,7 +216,7 @@ where
         use self::Term::*;
 
         match self {
-            Iri(iri) => iri.clone_with(factory).into(),
+            Iri(iri) => iri.clone_map(factory).into(),
             BNode(bn) => bn.clone_with(factory).into(),
             Literal(lit) => lit.clone_with(factory).into(),
             Variable(var) => var.clone_with(factory).into(),

--- a/term/src/lib.rs
+++ b/term/src/lib.rs
@@ -217,9 +217,9 @@ where
 
         match self {
             Iri(iri) => iri.clone_map(factory).into(),
-            BNode(bn) => bn.clone_with(factory).into(),
+            BNode(bn) => bn.clone_map(factory).into(),
             Literal(lit) => lit.clone_map(factory).into(),
-            Variable(var) => var.clone_with(factory).into(),
+            Variable(var) => var.clone_map(factory).into(),
         }
     }
 

--- a/term/src/lib.rs
+++ b/term/src/lib.rs
@@ -204,11 +204,60 @@ where
         Variable::new(name).map(Into::into)
     }
 
-    /// Clone another term with the given factory.
+    /// Borrow the inner contents of the term.
+    pub fn as_ref(&self) -> Term<&T> {
+        use self::Term::*;
+
+        match &self {
+            Iri(iri) => Iri(iri.as_ref()),
+            Literal(lit) => Literal(lit.as_ref()),
+            BNode(bn) => BNode(bn.as_ref()),
+            Variable(var) => Variable(var.as_ref()),
+        }
+    }
+
+    /// Borrow the inner contents of the term as `&str`.
+    pub fn as_ref_str(&self) -> Term<&str> {
+        use self::Term::*;
+
+        match &self {
+            Iri(iri) => Iri(iri.as_ref_str()),
+            Literal(lit) => Literal(lit.as_ref_str()),
+            BNode(bn) => BNode(bn.as_ref_str()),
+            Variable(var) => Variable(var.as_ref_str()),
+        }
+    }
+
+    /// Create a new term by applying `f` to the `TermData` of `self`.
+    pub fn map<F, TD2>(self, f: F) -> Term<TD2>
+    where
+        F: FnMut(T) -> TD2,
+        TD2: TermData,
+    {
+        use self::Term::*;
+
+        match self {
+            Iri(iri) => Iri(iri.map(f)),
+            Literal(lit) => Literal(lit.map(f)),
+            BNode(bn) => BNode(bn.map(f)),
+            Variable(var) => Variable(var.map(f)),
+        }
+    }
+
+    /// Maps the term using the `Into` trait.
+    pub fn map_into<TD2>(self) -> Term<TD2>
+    where
+        T: Into<TD2>,
+        TD2: TermData,
+    {
+        self.map(Into::into)
+    }
+
+    /// Clone self while transforming the inner `TermData` with the given
+    /// factory.
     ///
-    /// Clone as this might allocate a new `TermData`. However there is also
-    /// `TermData` that is cheap to clone, i.e. `Copy`.
-    pub fn clone_with<'a, U, F>(&'a self, factory: F) -> Term<U>
+    /// This is done in one step in contrast to calling `clone().map(factory)`.
+    pub fn clone_map<'a, U, F>(&'a self, factory: F) -> Term<U>
     where
         U: TermData,
         F: FnMut(&'a str) -> U,
@@ -223,6 +272,14 @@ where
         }
     }
 
+    /// Apply `clone_map()` using the `Into` trait.
+    pub fn clone_into<'src, U>(&'src self) -> Term<U>
+    where
+        U: TermData + From<&'src str>,
+    {
+        self.clone_map(Into::into)
+    }
+
     /// Transforms the underlying IRIs according to the given policy.
     ///
     /// If the policy already applies the Term is returned unchanged.
@@ -234,7 +291,7 @@ where
         match self {
             Term::Iri(iri) => iri.clone_normalized_with(policy, factory).into(),
             Term::Literal(lit) => lit.clone_normalized_with(policy, factory).into(),
-            _ => self.clone_with(factory),
+            _ => self.clone_map(factory),
         }
     }
 
@@ -426,16 +483,6 @@ where
             Term::Variable(var) => var == other,
             _ => false,
         }
-    }
-}
-
-impl<'a, T, U> From<&'a Term<U>> for Term<T>
-where
-    T: TermData + From<&'a str>,
-    U: TermData,
-{
-    fn from(other: &'a Term<U>) -> Term<T> {
-        other.clone_with(T::from)
     }
 }
 

--- a/term/src/literal.rs
+++ b/term/src/literal.rs
@@ -149,7 +149,7 @@ where
         let txt = factory(self.txt.as_ref());
         let kind = match &self.kind {
             Lang(tag) => Lang(factory(tag.as_ref())),
-            Dt(iri) => Dt(iri.clone_with(factory)),
+            Dt(iri) => Dt(iri.clone_map(factory)),
         };
 
         Literal { txt, kind }
@@ -440,7 +440,7 @@ mod test {
     #[test]
     fn convert_to_mown_does_not_allocate() {
         use crate::mown_str::MownStr;
-        let lit1 = Literal::<Box<str>>::new_dt("hello", &xsd::iri::string);
+        let lit1 = Literal::<Box<str>>::new_dt("hello", xsd::iri::string.map_into());
         let lit2 = Literal::<MownStr>::from(&lit1);
         let Literal { txt, .. } = lit2;
         if let MownStr::Own(_) = txt {

--- a/term/src/literal.rs
+++ b/term/src/literal.rs
@@ -237,8 +237,8 @@ where
     /// _Note:_ A language-tagged literal has always the type `rdf:langString`.
     pub fn dt(&self) -> Iri<&str> {
         match &self.kind {
-            Lang(_) => rdf::langString.try_into().expect("ensured"),
-            Dt(dt) => dt.into(),
+            Lang(_) => rdf::iri::langString,
+            Dt(dt) => dt.as_ref_str(),
         }
     }
 

--- a/term/src/literal.rs
+++ b/term/src/literal.rs
@@ -165,7 +165,7 @@ where
         }
     }
 
-    /// Create a new IRI by applying `f` to the `TermData` of `self`.
+    /// Create a new literal by applying `f` to the `TermData` of `self`.
     pub fn map<F, TD2>(self, f: F) -> Literal<TD2>
     where
         F: FnMut(TD) -> TD2,
@@ -182,7 +182,7 @@ where
         }
     }
 
-    /// Maps the IRI using the `Into` trait.
+    /// Maps the literal using the `Into` trait.
     pub fn map_into<TD2>(self) -> Literal<TD2>
     where
         TD: Into<TD2>,

--- a/term/src/literal/_convert.rs
+++ b/term/src/literal/_convert.rs
@@ -112,10 +112,7 @@ macro_rules! impl_as_literal {
             TD: $crate::TermData + From<String> + From<&'static str>,
         {
             fn as_literal(&self) -> Literal<TD> {
-                $crate::literal::Literal::new_dt(
-                    self.to_string(),
-                    Self::iri().clone_with(Into::into),
-                )
+                $crate::literal::Literal::new_dt(self.to_string(), Self::iri().clone_into())
             }
         }
     };

--- a/term/src/literal/_convert.rs
+++ b/term/src/literal/_convert.rs
@@ -112,7 +112,10 @@ macro_rules! impl_as_literal {
             TD: $crate::TermData + From<String> + From<&'static str>,
         {
             fn as_literal(&self) -> Literal<TD> {
-                $crate::literal::Literal::new_dt(self.to_string(), Self::iri())
+                $crate::literal::Literal::new_dt(
+                    self.to_string(),
+                    Self::iri().clone_with(Into::into),
+                )
             }
         }
     };

--- a/term/src/matcher.rs
+++ b/term/src/matcher.rs
@@ -180,7 +180,7 @@ impl<F: Fn(&RefTerm) -> bool> TermMatcher for F {
     where
         T: TermData,
     {
-        self(&RefTerm::from(t))
+        self(&t.as_ref_str())
     }
 }
 

--- a/term/src/mown_str.rs
+++ b/term/src/mown_str.rs
@@ -15,7 +15,7 @@ use std::ops::Deref;
 pub enum MownStr<'a> {
     /// Variant simply borrowing `str`
     Ref(&'a str),
-    /// Variany owning `str` into a box
+    /// Variant owning `str` into a box
     Own(Box<str>),
 }
 

--- a/term/src/test.rs
+++ b/term/src/test.rs
@@ -468,12 +468,33 @@ fn term_similar_but_not_eq() {
 }
 
 #[test]
+fn map() {
+    let mut cnt = 0;
+    let t = StaticTerm::new_iri_suffixed("http://champin.net/", "#pa").unwrap();
+    let t2 = t.map(|s| {
+        cnt += s.len();
+        String::from(s)
+    });
+    assert_eq!(cnt, "http://champin.net/".len() + "#pa".len());
+    assert_eq!(t2, Term::<&str>::new_iri("http://champin.net/#pa").unwrap());
+}
+
+#[test]
+fn map_into() {
+    let t1 = StaticTerm::new_iri("http://champin.net/#pa").unwrap();
+    let t2 = t1.map_into::<Box<str>>();
+    let _3 = t2.clone().map_into::<Rc<str>>();
+    let _4 = t2.clone().map_into::<Arc<str>>();
+    let _5 = t2.map_into::<String>();
+}
+
+#[test]
 fn convert() {
     let t1 = StaticTerm::new_iri("http://champin.net/#pa").unwrap();
-    let t2 = BoxTerm::from(&t1);
-    let t3 = RcTerm::from(&t2);
-    let t4 = ArcTerm::from(&t3);
-    let _t = RefTerm::from(&t4);
+    let t2 = t1.clone_into::<Box<str>>();
+    let t3 = t2.clone_into::<Rc<str>>();
+    let t4 = t3.clone_into::<Arc<str>>();
+    let _5 = t4.clone_into::<&str>();
 }
 
 pub(crate) const POSITIVE_1CHAR_IDS: &[&str] = &[

--- a/term/src/test.rs
+++ b/term/src/test.rs
@@ -154,7 +154,7 @@ fn bnode() {
     assert_eq!(&format!("{}", b1), "_:foo");
 
     if let BNode(id1) = b1 {
-        assert_eq!(AsRef::<str>::as_ref(&id1), "foo");
+        assert_eq!(id1.as_str(), "foo");
     } else {
         panic!("b1 should be a BNode");
     }

--- a/term/src/variable.rs
+++ b/term/src/variable.rs
@@ -296,4 +296,38 @@ mod test {
             Err(_) => b"failed write".to_vec(),
         }
     }
+
+    #[test]
+    fn map() {
+        let input: Variable<&str> = Variable::new("test").unwrap();
+        let expect: Variable<&str> = Variable::new("TEST").unwrap();
+
+        let mut cnt = 0;
+        let mut invoked = 0;
+
+        let cl = input.clone_map(|s: &str| {
+            cnt += s.len();
+            invoked += 1;
+            s.to_ascii_uppercase()
+        });
+        assert_eq!(cl, expect);
+        assert_eq!(cnt, "test".len());
+        assert_eq!(invoked, 1);
+
+        cnt = 0;
+        invoked = 0;
+        let mapped = input.map(|s: &str| {
+            cnt += s.len();
+            invoked += 1;
+            s.to_ascii_uppercase()
+        });
+        assert_eq!(mapped, expect);
+        assert_eq!(cnt, "test".len());
+        assert_eq!(invoked, 1);
+
+        assert_eq!(
+            cl.map_into::<Box<str>>(),
+            mapped.clone_into::<std::sync::Arc<str>>()
+        );
+    }
 }

--- a/term/src/variable.rs
+++ b/term/src/variable.rs
@@ -124,7 +124,7 @@ where
     }
 
     /// Borrow the variables ID.
-    /// 
+    ///
     /// _Note:_ The ID does not have a leading `_:`.
     pub fn as_str(&self) -> &str {
         self.0.as_ref()


### PR DESCRIPTION
Allows better control over ownership and transformation of 'TermData'.

The idea originated from this recent topic at URLO: https://users.rust-lang.org/t/is-it-possible-to-impl-from-wrapper-t-for-wrapper-u/40029/3

With `map()` is is possible to directly map owned `TermData`. At the moment transformation is usually done through reference via `Self<T>: From<&Self<U>>`. This rather implicit conversion can now be replaced by more explicit `self.as_ref().map(...)`. Furthermore, this can become handy for handling intermediate `String`s (#60). Another example is `term.as_ref_str()` instead of `RefTerm::from(&term)`.

---

**WIP**

At the moment this PR is more a PoC and methods are only implemented for `Iri`.