### PR TITLE
Improve Namespace's API

### DIFF
--- a/term/src/_error.rs
+++ b/term/src/_error.rs
@@ -14,9 +14,10 @@ pub enum TermError {
     /// The IRI of a term must apply to [RFC 3987](https://tools.ietf.org/html/rfc3987).
     #[error("The given IRI '{0}' is not valid according to RFC3987")]
     InvalidIri(String),
-    /// An IRI must be represented by one `TermData` to be able to parse its components.
-    #[error("IRI components could not be parsed in one as it has a suffix")]
-    IriParse,
+    /// An IRI must be represented by one `TermData` to be able to convert it
+    /// to a `Namespace`.
+    #[error("IRI components could not be turned into a `Namespace` as it has a suffix")]
+    IsSuffixed,
     /// The language tags of literals must apply to [BCP47](https://tools.ietf.org/html/bcp47).
     #[error("The given language tag '{tag}' is not valid according to BCP47: {err}")]
     InvalidLanguageTag {
@@ -25,7 +26,7 @@ pub enum TermError {
         /// What is wrong with `tag`.
         err: String,
     },
-    /// The lexical value of a literal can not be interpreted accortding to its datatype
+    /// The lexical value of a literal can not be interpreted according to its datatype
     #[error("The given lexical value '{lex}' is invalid for datatype {dt}")]
     InvalidLexicalValue {
         /// The faulty lexical value.

--- a/term/src/iri.rs
+++ b/term/src/iri.rs
@@ -22,6 +22,7 @@ pub use self::_join::*;
 
 use super::{Result, Term, TermData, TermError};
 use crate::mown_str::MownStr;
+use crate::ns::Namespace;
 use std::convert::TryFrom;
 use std::fmt;
 use std::hash::{Hash, Hasher};
@@ -586,6 +587,20 @@ where
         state.write(self.ns.as_ref().as_bytes());
         state.write(self.suffix_as_str().as_bytes());
         state.write_u8(0xff);
+    }
+}
+
+impl<TD> From<Namespace<TD>> for Iri<TD>
+where
+    TD: TermData,
+{
+    fn from(ns: Namespace<TD>) -> Self {
+        // Already checked if its a valid IRI
+        Iri {
+            absolute: is_absolute_iri_ref(ns.0.as_ref()),
+            ns: ns.0,
+            suffix: None,
+        }
     }
 }
 

--- a/term/src/iri/_join.rs
+++ b/term/src/iri/_join.rs
@@ -6,8 +6,8 @@
 
 use super::{Iri, IRELATIVE_REF_REGEX, IRI_REGEX};
 use crate::mown_str::MownStr;
-use crate::{Literal, MownTerm, Result, Term, TermData, TermError};
 use crate::ns::Namespace;
+use crate::{Literal, MownTerm, Result, Term, TermData, TermError};
 use std::fmt;
 
 /// Resolve some kind of IRI with `self` as the base.


### PR DESCRIPTION
Result of the discussion in #62 

- Add 'get_iri()'
- Conversion between 'Iri' and 'Namespace'
- Impl Resolve<Namespace>