### PR TITLE
simplify the Resolve trait implementation

### DIFF
--- a/jsonld/src/test_util.rs
+++ b/jsonld/src/test_util.rs
@@ -82,6 +82,7 @@ impl<'a> Test<'a> {
             .iri()
             .parse_components(&mut buffer)
             .resolve(&test_iri)
+            .map_into()
     }
 
     pub fn positive(&self) -> bool {

--- a/term/src/iri/_join.rs
+++ b/term/src/iri/_join.rs
@@ -186,12 +186,12 @@ where
     }
 }
 
-impl<'td, 'base, TD> Resolve<&'td Namespace<TD>, Namespace<MownStr<'td>>> for IriParsed<'base>
+impl<'a, 'b, TD> Resolve<&'a Namespace<TD>, Namespace<MownStr<'a>>> for IriParsed<'b>
 where
-    TD: 'td + TermData,
+    TD: TermData,
 {
     /// Resolve the IRI of the given `Namespace`.
-    fn resolve(&self, other: &'td Namespace<TD>) -> Namespace<MownStr<'td>> {
+    fn resolve(&self, other: &'a Namespace<TD>) -> Namespace<MownStr<'a>> {
         let iri = other.0.as_ref();
         let resolved: MownStr = self.resolve(iri).expect("Is valid as from Namespace");
         Namespace(resolved)
@@ -200,15 +200,12 @@ where
 
 impl<'a, 'b, TD> Resolve<&'a Literal<TD>, Literal<MownStr<'a>>> for IriParsed<'b>
 where
-    TD: TermData + 'a,
+    TD: TermData,
 {
     /// Resolve the data type's IRI if it is relative.
     ///
-    /// # Exception
-    ///
-    /// This only changes on `Typed` literals.
-    /// Language-tagged literals are absolute by construction.
-    /// Therefore, those are not affected.
+    /// Note that this only affects datatyped literals;
+    /// language-tagged literals are absolute by construction.
     ///
     /// # Performance
     ///
@@ -217,8 +214,6 @@ where
         if other.is_absolute() {
             other.clone_into()
         } else {
-            // other is necessarily a datatype literal
-            // (because language tagged literals are always absolute)
             Literal::new_dt(other.txt().as_ref(), self.resolve(other.dt()))
         }
     }

--- a/term/src/iri/_join.rs
+++ b/term/src/iri/_join.rs
@@ -155,24 +155,6 @@ impl<'a> Resolve<&'a IriParsed<'a>, IriParsed<'a>> for IriParsed<'a> {
     }
 }
 
-impl<'a, 'b, TD, TD2> Resolve<&'a Iri<TD>, Iri<TD2>> for IriParsed<'b>
-where
-    TD: TermData,
-    TD2: TermData + for<'x> From<&'x str>,
-{
-    /// Resolve the given IRI.
-    ///
-    /// # Performance
-    ///
-    /// May allocate an intermediate IRI if `other` is suffixed.
-    fn resolve(&self, other: &Iri<TD>) -> Iri<TD2> {
-        let mut buffer = String::new();
-        let parsed = other.parse_components(&mut buffer);
-        let joined = self.join(&parsed);
-        Iri::new_unchecked(joined.to_string().as_str(), joined.is_absolute())
-    }
-}
-
 impl<'a, 'b, TD> Resolve<&'a Iri<TD>, Iri<MownStr<'a>>> for IriParsed<'b>
 where
     TD: TermData,
@@ -193,19 +175,6 @@ where
     }
 }
 
-impl<'o, 'base, TD, TD2> Resolve<&'o Namespace<TD>, Namespace<TD2>> for IriParsed<'base>
-where
-    TD: TermData,
-    TD2: TermData + for<'x> From<&'x str>,
-{
-    /// Resolve the IRI of the given `Namespace`.
-    fn resolve(&self, other: &'o Namespace<TD>) -> Namespace<TD2> {
-        let resolved: Namespace<MownStr> = self.resolve(other);
-        let resolved = TD2::from(resolved.0.as_ref());
-        Namespace(resolved)
-    }
-}
-
 impl<'td, 'base, TD> Resolve<&'td Namespace<TD>, Namespace<MownStr<'td>>> for IriParsed<'base>
 where
     TD: 'td + TermData,
@@ -215,32 +184,6 @@ where
         let iri = other.0.as_ref();
         let resolved: MownStr = self.resolve(iri).expect("Is valid as from Namespace");
         Namespace(resolved)
-    }
-}
-
-impl<'a, 'b, TD, TD2> Resolve<&'a Literal<TD>, Literal<TD2>> for IriParsed<'b>
-where
-    TD: TermData,
-    TD2: TermData + for<'x> From<&'x str>,
-{
-    /// Resolve the data type's IRI if it is relative.
-    ///
-    /// # Exception
-    ///
-    /// This only changes on `Typed` literals.
-    /// Language-tagged literals are absolute by construction.
-    /// Therefore, those are not affected.
-    ///
-    /// # Performance
-    ///
-    /// May allocate an intermediate IRI if `other.dt()` is suffixed.
-    fn resolve(&self, other: &'a Literal<TD>) -> Literal<TD2> {
-        if other.is_absolute() {
-            other.clone_into()
-        } else {
-            let dt: Iri<TD2> = self.resolve(&other.dt());
-            Literal::new_dt(other.txt().as_ref(), dt)
-        }
     }
 }
 
@@ -270,25 +213,6 @@ where
                 self.is_absolute(),
             );
             Literal::new_dt(other.txt().as_ref(), dt)
-        }
-    }
-}
-
-impl<'a, 'b, TD, TD2> Resolve<&'a Term<TD>, Term<TD2>> for IriParsed<'b>
-where
-    TD: TermData,
-    TD2: TermData + for<'x> From<&'x str>,
-{
-    /// Resolve IRIs and the IRIs of typed literals.
-    ///
-    /// # Performance
-    ///
-    /// May allocate an intermediate IRI if an IRI is suffixed.
-    fn resolve(&self, other: &'a Term<TD>) -> Term<TD2> {
-        match other {
-            Term::Iri(iri) => Resolve::<_, Iri<TD2>>::resolve(self, iri).into(),
-            Term::Literal(lit) => Resolve::<_, Literal<TD2>>::resolve(self, lit).into(),
-            term => term.clone_into(),
         }
     }
 }
@@ -363,7 +287,7 @@ fn remove_dot_segments(path: &mut Vec<&str>) {
 mod test {
     use super::super::test::{NEGATIVE_IRIS, POSITIVE_IRIS, RELATIVE_IRIS};
     use super::*;
-    use crate::{BoxTerm, RefTerm};
+    use crate::RefTerm;
 
     #[test]
     fn positive() {
@@ -427,63 +351,42 @@ mod test {
     }
 
     #[test]
-    fn resolve_iri_mown() {
+    fn resolve_namespace() {
+        let base = IriParsed::new("http://a/b/c/d;p?q").unwrap();
+        for (rel, abs) in RELATIVE_IRIS {
+            let rel = Namespace::<&str>::new(*rel).unwrap();
+            let got = base.resolve(&rel);
+            assert_eq!(&got.as_ref(), abs);
+        }
+    }
+
+    #[test]
+    fn resolve_iri() {
         let base = IriParsed::new("http://a/b/c/d;p?q").unwrap();
         for (rel, abs) in RELATIVE_IRIS {
             let rel = Iri::<&str>::new(*rel).unwrap();
-            let got: Iri<MownStr> = base.resolve(&rel);
+            let got = base.resolve(&rel);
             assert_eq!(&got.value(), abs);
         }
     }
 
     #[test]
-    fn resolve_iri_box() {
-        let base = IriParsed::new("http://a/b/c/d;p?q").unwrap();
-        for (rel, abs) in RELATIVE_IRIS {
-            let rel = Iri::<&str>::new(*rel).unwrap();
-            let got: Iri<Box<str>> = base.resolve(&rel);
-            assert_eq!(&got.value(), abs);
-        }
-    }
-
-    #[test]
-    fn resolve_literal_mown() {
+    fn resolve_literal() {
         let base = IriParsed::new("http://a/b/c/d;p?q").unwrap();
         for (rel, abs) in RELATIVE_IRIS {
             let rel = Iri::<&str>::new(*rel).unwrap();
             let lit = Literal::<&str>::new_dt("hello", rel);
-            let got: Literal<MownStr> = base.resolve(&lit);
+            let got = base.resolve(&lit);
             assert_eq!(&got.dt().value(), abs);
         }
     }
 
     #[test]
-    fn resolve_literal_box() {
-        let base = IriParsed::new("http://a/b/c/d;p?q").unwrap();
-        for (rel, abs) in RELATIVE_IRIS {
-            let rel = Iri::<&str>::new(*rel).unwrap();
-            let lit = Literal::<&str>::new_dt("hello", rel);
-            let got: Literal<Box<str>> = base.resolve(&lit);
-            assert_eq!(&got.dt().value(), abs);
-        }
-    }
-
-    #[test]
-    fn resolve_iri_term_mown() {
+    fn resolve_iri_term() {
         let base = IriParsed::new("http://a/b/c/d;p?q").unwrap();
         for (rel, abs) in RELATIVE_IRIS {
             let rel = RefTerm::new_iri(*rel).unwrap();
-            let got: MownTerm = base.resolve(&rel);
-            assert_eq!(&got.value(), abs);
-        }
-    }
-
-    #[test]
-    fn resolve_iri_term_box() {
-        let base = IriParsed::new("http://a/b/c/d;p?q").unwrap();
-        for (rel, abs) in RELATIVE_IRIS {
-            let rel = RefTerm::new_iri(*rel).unwrap();
-            let got: BoxTerm = base.resolve(&rel);
+            let got = base.resolve(&rel);
             assert_eq!(&got.value(), abs);
         }
     }


### PR DESCRIPTION
This commit remove somewhat redundant implementations;
the rationale is that what they did (resolving TD1 to TD2 directly)
can usually be achieved by resolving to MownStr, then map'ing to TD2.
This will usually be just as efficient (possibly more),
because types that can recycle the memory allocated by MownStr will
usually do so (e.g. Box or String).

@MattesWhite what do you think about that. You designed and implemented the `Resolve` trait,
so I would like your opinion on this before merging it.