### PR TITLE
Optimize 'Resolve<Literal>'

### DIFF
--- a/term/src/iri/_join.rs
+++ b/term/src/iri/_join.rs
@@ -244,36 +244,6 @@ where
     }
 }
 
-impl<'a, 'b, TD> Resolve<&'a Literal<TD>, Literal<MownStr<'a>>> for IriParsed<'b>
-where
-    TD: TermData + 'a,
-{
-    /// Resolve the data type's IRI if it is relative.
-    ///
-    /// # Exception
-    ///
-    /// This only changes on `Typed` literals.
-    /// Language-tagged literals are absolute by construction.
-    /// Therefore, those are not affected.
-    ///
-    /// # Performance
-    ///
-    /// May allocate an intermediate IRI if `other.dt()` is suffixed.
-    fn resolve(&self, other: &'a Literal<TD>) -> Literal<MownStr<'a>> {
-        if other.is_absolute() {
-            other.clone_into()
-        } else {
-            let dt = Iri::<MownStr>::new_unchecked(
-                self.resolve(other.dt().value().as_ref())
-                    .unwrap()
-                    .to_string(),
-                self.is_absolute(),
-            );
-            Literal::new_dt(other.txt().as_ref(), dt)
-        }
-    }
-}
-
 impl<'a, 'b, TD, TD2> Resolve<&'a Term<TD>, Term<TD2>> for IriParsed<'b>
 where
     TD: TermData,


### PR DESCRIPTION
The current implementation of `impl Resolve<Literal> for IriParsed` is not optimal as it allocates intermediate string(s).

This implementation uses the standard `Resolve<Iri>` for the literal's datatype and wraps the text as `MownStr::Ref`. The key for this implementation is to move it into the `literal` module where we can access the private fields of `Literal`.