### PR TITLE
Change getting started example

### DIFF
--- a/sophia/src/lib.rs
+++ b/sophia/src/lib.rs
@@ -38,7 +38,6 @@
 //! use sophia::serializer::nt::NtSerializer;
 //! use sophia::triple::stream::TripleSource;
 //!
-//! # fn main() -> Result<(), CatchAll> {
 //! let example = r#"
 //!     @prefix : <http://example.org/>.
 //!     @prefix foaf: <http://xmlns.com/foaf/0.1/>.
@@ -62,11 +61,7 @@
 //! let mut nt_stringifier = NtSerializer::new_stringifier();
 //! let example2 = nt_stringifier.serialize_graph(&mut graph)?.as_str();
 //! println!("The resulting graph\n{}", example2);
-//! # Ok(())}
-//! #
-//! # #[derive(Debug)]
-//! # pub struct CatchAll();
-//! # impl<T: std::error::Error> From<T> for CatchAll { fn from(_: T) -> Self {CatchAll()}}
+//! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
 
 pub mod dataset;


### PR DESCRIPTION
In fact, this PR changes nothing for users but removes some boilerplate code. Therefore, it is okay to close this PR. It is rather a minor recommendation for the future.

The change uses the trick from [`rustdoc`'s documentation](https://doc.rust-lang.org/rustdoc/documentation-tests.html#using--in-doc-tests): As of Rust 1.34 we can omit the `fn main() -> Result<...>` when an `Ok::<...>(())` is returned.

_Note:_ `Box<dyn std::error::Error>` is already semantically equal to `CatchAll`.