### PR TITLE
More factories

### DIFF
--- a/sophia/src/graph/inmem/_term_index_map_u.rs
+++ b/sophia/src/graph/inmem/_term_index_map_u.rs
@@ -90,6 +90,7 @@ impl<T, F> TermIndexMap for TermIndexMapU<T, F>
 where
     T: Unsigned,
     F: TermFactory + Default,
+    <F as TermFactory>::TermData: for<'x> From<&'x str>,
 {
     type Index = T;
     type Factory = F;


### PR DESCRIPTION
The `TermFactory`-trait is useful in many occasions where someone tries to build dynamically new terms (especially blank nodes).

However, for now only factories for `Rc<str>` and `Arc<str>` where provided. This PR add a `SimpleFactory` when expected `TermData` can be directly converted, e.g. `String` to `Box<str>` and an implementation for closures.

In addtion, I did a small simplification of the `TermFactory` trait.