### PR TITLE
Fix dead links and typos

### DIFF
--- a/api/src/dataset/adapter/_error.rs
+++ b/api/src/dataset/adapter/_error.rs
@@ -6,9 +6,9 @@ use std::error::Error;
 /// _Note:_ MGE is the [mutation error] of the wrapped [`MutableGraph`].
 ///
 /// [adapter]: ./struct.GraphAsDataset.html
-/// [`MutableGraph`]: ../trait.MutableGraph.html
-/// [`MutableDataset`]: ../../dataset/trait.MutableDataset.html
-/// [mutation error]: ../trait.MutableGraph.html#associatedtype.MutationError
+/// [`MutableGraph`]: ../../graph/trait.MutableGraph.html
+/// [`MutableDataset`]: ../trait.MutableDataset.html
+/// [mutation error]: ../../graph/trait.MutableGraph.html#associatedtype.MutationError
 #[derive(Debug, thiserror::Error)]
 pub enum GraphAsDatasetError<MGE: 'static + Error> {
     /// Raised when the [adapter] is requested to modify a triple in a named

--- a/api/src/dataset/adapter/_graph_as_dataset.rs
+++ b/api/src/dataset/adapter/_graph_as_dataset.rs
@@ -15,9 +15,9 @@ use crate::term::TTerm;
 use super::GraphAsDatasetError;
 
 /// The adapter returned by
-/// * [`Graph::as_dataset`](../trait.Graph.html#method.as_dataset)
-/// * [`Graph::as_dataset_mut`](../trait.Graph.html#method.as_dataset_mut)
-/// * [`Graph::into_dataset`](../trait.Graph.html#method.into_dataset)
+/// * [`Graph::as_dataset`](../../graph/trait.Graph.html#method.as_dataset)
+/// * [`Graph::as_dataset_mut`](../../graph/trait.Graph.html#method.as_dataset_mut)
+/// * [`Graph::into_dataset`](../../graph/trait.Graph.html#method.into_dataset)
 pub struct GraphAsDataset<G: ?Sized, H = G>(H, PhantomData<G>);
 
 impl<G: ?Sized, H> GraphAsDataset<G, H> {

--- a/api/src/dataset/test.rs
+++ b/api/src/dataset/test.rs
@@ -119,18 +119,18 @@ where
 /// It accepts the following parameters:
 /// * `module_name`: the name of the module to generate (defaults to `test`);
 /// * `dataset_impl`: the type to test, implementing [`Dataset`], [`CollectibleDataset`] and [`MutableDataset`];
-/// * `is_set`: a boolean, indicating if `dataset_impl` implements [`SetDataset`]
+/// * `is_set`: a Boolean, indicating if `dataset_impl` implements [`SetDataset`]
 ///   (defaults to `true`);
-/// * `is_gen`: a boolean, indicating if `dataset_impl` supports the [generalized model]
+/// * `is_gen`: a Boolean, indicating if `dataset_impl` supports the [generalized model]
 ///   (defaults to `true`).
-/// * `dataset_collector`: a function used to create an empy instance of `dataset_impl`
+/// * `dataset_collector`: a function used to create an empty instance of `dataset_impl`
 ///   (defaults to `dataset_impl::from_quad_source`);
 /// * `mt` is used internally, do not touch it...
 ///
 /// [`Dataset`]: dataset/trait.Dataset.html
 /// [`CollectibleDataset`]: dataset/trait.CollectibleDataset.html
 /// [`MutableDataset`]: dataset/trait.MutableDataset.html
-/// [`test_immutable_dataset_impl`]: ./macro.test_immutable_dataset_impl
+/// [`test_immutable_dataset_impl`]: ./macro.test_immutable_dataset_impl.html
 /// [`SetDataset`]: dataset/trait.SetDataset.html
 /// [generalized model]: ./index.html
 #[macro_export]
@@ -852,9 +852,9 @@ macro_rules! test_dataset_impl {
 /// It accepts the following parameters:
 /// * `module_name`: the name of the module to generate (defaults to `test`);
 /// * `dataset_impl`: the type to test, implementing [`Dataset`] and [`CollectibleDataset`];
-/// * `is_set`: a boolean, indicating if `dataset_impl` implements [`SetDataset`]
+/// * `is_set`: a Boolean, indicating if `dataset_impl` implements [`SetDataset`]
 ///   (defaults to `true`);
-/// * `is_gen`: a boolean, indicating if `dataset_impl` supports the [generalized model]
+/// * `is_gen`: a Boolean, indicating if `dataset_impl` supports the [generalized model]
 ///   (defaults to `true`);
 /// * `dataset_collector`: a function used to collect quads into an instance of `dataset_impl`
 ///   (defaults to `dataset_impl::from_quad_source`);
@@ -862,7 +862,7 @@ macro_rules! test_dataset_impl {
 /// [`Dataset`]: dataset/trait.Dataset.html
 /// [`CollectibleDataset`]: dataset/trait.CollectibleDataset.html
 /// [`MutableDataset`]: dataset/trait.MutableDataset.html
-/// [`test_dataset_impl`]: ./macro.test_dataset_impl
+/// [`test_dataset_impl`]: ./macro.test_dataset_impl.html
 /// [`SetDataset`]: dataset/trait.SetDataset.html
 /// [generalized model]: ./index.html
 #[macro_export]

--- a/api/src/graph/test.rs
+++ b/api/src/graph/test.rs
@@ -155,7 +155,7 @@ where
 /// [`Graph`]: graph/trait.Graph.html
 /// [`CollectibleGraph`]: graph/trait.CollectibleGraph.html
 /// [`MutableGraph`]: graph/trait.MutableGraph.html
-/// [`test_immutable_graph_impl`]: ./macro.test_immutable_graph_impl
+/// [`test_immutable_graph_impl`]: ./macro.test_immutable_graph_impl.html
 /// [`SetGraph`]: graph/trait.SetGraph.html
 /// [generalized model]: ./index.html
 #[macro_export]
@@ -612,7 +612,7 @@ macro_rules! test_graph_impl {
 /// [`Graph`]: graph/trait.Graph.html
 /// [`CollectibleGraph`]: graph/trait.CollectibleGraph.html
 /// [`MutableGraph`]: graph/trait.MutableGraph.html
-/// [`test_graph_impl`]: ./macro.test_graph_impl
+/// [`test_graph_impl`]: ./macro.test_graph_impl.html
 /// [`SetGraph`]: graph/trait.SetGraph.html
 /// [generalized model]: ./index.html
 #[macro_export]

--- a/api/src/parser/_location.rs
+++ b/api/src/parser/_location.rs
@@ -61,9 +61,6 @@ impl fmt::Display for Position {
 }
 
 /// This trait is meant to be implemented by errors raised by parsers.
-///
-/// See also [`LocatableError`](./trait.LocatableError.html)
-/// and [`LocatableResult`](./trait.LocatableResult.html).
 pub trait WithLocation {
     fn location(&self) -> Location;
 }

--- a/api/src/quad.rs
+++ b/api/src/quad.rs
@@ -1,5 +1,5 @@
 //! A quad expresses a single fact within a context.
-//! Quads are like RDF `triples`(../triple/index.html)
+//! Quads are like RDF [`triples`](../triple/index.html)
 //! augmented with an optional graph name.
 //!
 //! They are the individual statements of an RDF `dataset`(../dataset/index.html).

--- a/api/src/quad/stream.rs
+++ b/api/src/quad/stream.rs
@@ -44,9 +44,9 @@ pub trait QuadSource {
     /// The type of errors produced by this source.
     type Error: 'static + Error;
 
-    /// Determine the type of [`Quad`](../quad/trait.Quad.html)s
+    /// Determine the type of [`Quad`](../trait.Quad.html)s
     /// that this quad source yields.
-    /// (see [`streaming_mode`](../quad/streaming_mode/index.html)
+    /// (see [`streaming_mode`](../streaming_mode/index.html)
     type Quad: QuadStreamingMode;
 
     /// Call f for at least one quad from this quad source, if any.

--- a/api/src/term.rs
+++ b/api/src/term.rs
@@ -55,15 +55,15 @@ pub use simple_iri::SimpleIri;
 ///
 /// * if it implements [`Hash`](https://doc.rust-lang.org/std/hash/trait.Hash.html),
 ///   it must be consistent with (or, even better, based on)
-///   [`term_hash`](./function.term_hash.html);
+///   [`term_hash`](./fn.term_hash.html);
 ///
 /// * if it implements [`PartialEq`](https://doc.rust-lang.org/std/cmp/trait.PartialEq.html),
 ///   it must be consistent with (or, even better, based on)
-///   [`term_eq`](./function.term_eq.html);
+///   [`term_eq`](./fn.term_eq.html);
 ///
 /// * if it implements [`PartialCmp`](https://doc.rust-lang.org/std/cmp/trait.PartialCmp.html)
 ///   it must be consistent with (or, even better, based on)
-///   [`term_cmp`](./function.term_cmp.html);
+///   [`term_cmp`](./fn.term_cmp.html);
 pub trait TTerm {
     /// Returns the kind of this term (IRI, literal, blank node, variable).
     fn kind(&self) -> TermKind;
@@ -145,7 +145,7 @@ pub trait TTerm {
     fn as_dyn(&self) -> &dyn TTerm;
 }
 
-/// Any [`TTerm`](./trait.TTerm.html) belongs to one those kinds.
+/// Any [`TTerm`](./trait.TTerm.html) belongs to one of those kinds.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub enum TermKind {
     /// RDF [IRI](https://www.w3.org/TR/rdf11-concepts/#section-IRIs),

--- a/api/src/term/_graph_name_matcher.rs
+++ b/api/src/term/_graph_name_matcher.rs
@@ -5,7 +5,7 @@ use crate::term::*;
 
 /// Generic trait for matching graph names, *i.e.* optional [term]s.
 ///
-/// [term]: ../enum.Term.html
+/// [term]: ../trait.TTerm.html
 pub trait GraphNameMatcher {
     /// Type of `TTerm` used internally by this matcher.
     type Term: TTerm + ?Sized;

--- a/api/src/term/matcher.rs
+++ b/api/src/term/matcher.rs
@@ -6,12 +6,12 @@
 //! [`GraphNameMatcher`'s implementors lists](trait.GraphNameMatcher.html#implementors).
 //!
 //! For methods using matchers (with examples), see for example
-//! [`Graph::triples_matching`](https://docs.rs/sophia/latest/sophia/graph/trait.Graph.html#method.triples_matching),
-//! [`MutableGraph::remove_matching`](https://docs.rs/sophia/latest/sophia/graph/trait.MutableGraph.html#method.remove_matching),
-//! [`MutableGraph::retain_matching`](https://docs.rs/sophia/latest/sophia/graph/trait.MutableGraph.html#method.retain_matching),
-//! [`Dataset::quads_matching`](https://docs.rs/sophia/latest/sophia/dataset/trait.Dataset.html#method.quads_matching),
-//! [`MutableDataset::remove_matching`](https://docs.rs/sophia/latest/sophia/dataset/trait.MutableDataset.html#method.remove_matching),
-//! [`MutableDataset::retain_matching`](https://docs.rs/sophia/latest/sophia/dataset/trait.MutableDataset.html#method.retain_matching).
+//! [`Graph::triples_matching`](../../graph/trait.Graph.html#method.triples_matching),
+//! [`MutableGraph::remove_matching`](../../graph/trait.MutableGraph.html#method.remove_matching),
+//! [`MutableGraph::retain_matching`](../../graph/trait.MutableGraph.html#method.retain_matching),
+//! [`Dataset::quads_matching`](../../dataset/trait.Dataset.html#method.quads_matching),
+//! [`MutableDataset::remove_matching`](../../dataset/trait.MutableDataset.html#method.remove_matching),
+//! [`MutableDataset::retain_matching`](../../dataset/trait.MutableDataset.html#method.retain_matching).
 //!
 
 use super::*;
@@ -20,7 +20,7 @@ pub use super::_graph_name_matcher::*;
 
 /// Generic trait for matching [term]s.
 ///
-/// [term]: ../enum.Term.html
+/// [term]: ../trait.TTerm.html
 pub trait TermMatcher {
     /// Type of `TTerm` used internally by this matcher.
     type Term: TTerm + ?Sized;
@@ -279,7 +279,7 @@ mod test {
     #[test]
     fn test_aoe_exactly_as_matcher() {
         let m = AnyOrExactly::Exactly(SimpleIri::new("http://champin.net/#pa", None).unwrap());
-        // comparing to a term using a difSimferent term data, and differently cut,
+        // comparing to a term using a different term data, and differently cut,
         // to make the test less obvious
         let t1 = SimpleIri::new("http://champin.net/#", Some("pa")).unwrap();
         let t2 = SimpleIri::new("http://example.org/", None).unwrap();
@@ -307,7 +307,7 @@ mod test {
     fn test_aoer_exactly_as_matcher() {
         let t = SimpleIri::new("http://champin.net/#pa", None).unwrap();
         let m = AnyOrExactlyRef::Exactly(&t);
-        // comparing to a term using a difSimferent term data, and differently cut,
+        // comparing to a term using a different term data, and differently cut,
         // to make the test less obvious
         let t1 = SimpleIri::new("http://champin.net/#", Some("pa")).unwrap();
         let t2 = SimpleIri::new("http://example.org/", None).unwrap();

--- a/api/src/term/simple_iri.rs
+++ b/api/src/term/simple_iri.rs
@@ -1,4 +1,4 @@
-//! Minimal implementation of [`TTerm`](../trait.TTerm.html),
+//! Minimal implementation of [`TTerm`](https://docs.rs/sophia_api/latest/sophia_api/term/trait.TTerm.html),
 //! for representing datatype IRIs of literals.
 use super::*;
 use sophia_iri::error::{InvalidIri, Result};

--- a/api/src/triple/stream.rs
+++ b/api/src/triple/stream.rs
@@ -58,7 +58,7 @@ pub use self::_iterator::*;
 mod _map;
 pub use self::_map::*;
 
-/// Type alias for referencing the `Term` used in a `TripleSoDataurce`.
+/// Type alias for referencing the `Term` used in a `TripleSource`.
 pub type TSTerm<S> =
     <<<S as TripleSource>::Triple as TripleStreamingMode>::UnsafeTriple as UnsafeTriple>::Term;
 
@@ -72,9 +72,9 @@ pub trait TripleSource {
     /// The type of errors produced by this source.
     type Error: 'static + Error;
 
-    /// Determine the type of [`Triple`](../triple/trait.Triple.html)s
+    /// Determine the type of [`Triple`](../trait.Triple.html)s
     /// that this triple source yields.
-    /// (see [`streaming_mode`](../triple/streaming_mode/index.html)
+    /// (see [`streaming_mode`](../streaming_mode/index.html)
     type Triple: TripleStreamingMode;
 
     /// Call f for at least one triple from this triple source, if any.

--- a/api/src/triple/streaming_mode.rs
+++ b/api/src/triple/streaming_mode.rs
@@ -47,7 +47,7 @@
 //! [`Triple`] (see its documentation for more details).
 //!
 //! NB: actually, another mode exists,
-//! but is specifically designed for the [`graph::adapter`](../../graph/adapter/index.html) module,
+//! but is specifically designed for the [`dataset::adapter`](../../dataset/adapter/index.html) module,
 //! should never be needed in other contexts.
 //!
 //! [`ByRef<T>`]: struct.ByRef.html

--- a/sophia/src/dataset/indexed.rs
+++ b/sophia/src/dataset/indexed.rs
@@ -47,7 +47,7 @@ pub trait IndexedDataset {
     /// As a consequence, this methods returns *an option of option* :
     /// * `None` means that given index is *not* associated to any graph name,
     /// * `Some(None)` means that the given index is associated to the default graph,
-    /// * `Some(Some(term))` means that given index is associetd to a proper graph name.
+    /// * `Some(Some(term))` means that given index is associated to a proper graph name.
     #[allow(clippy::option_option)]
     fn get_graph_name(&self, i: Self::Index) -> Option<Option<&Term<Self::TermData>>>;
 
@@ -85,7 +85,7 @@ pub trait IndexedDataset {
 /// Defines the implementation of [`CollectibleDataset`] for [`IndexedDataset`].
 ///
 /// [`CollectibleDataset`]: dataset/trait.CollectibleDataset.html
-/// [`IndexedDataset`]: dataset/indexed/trait.IndexedGraph.html
+/// [`IndexedDataset`]: dataset/indexed/trait.IndexedDataset.html
 #[macro_export]
 macro_rules! impl_collectible_dataset_for_indexed_dataset {
     ($indexed_mutable_dataset: ty) => {


### PR DESCRIPTION
This PR fixes a lot of dead links in the docs as well as some typos.

For detecting dead links in documentation I used [cargo-deadlinks](https://github.com/deadlinks/cargo-deadlinks).