### PR TITLE
Improve doc coverage (#44)

### DIFF
--- a/api/src/quad/streaming_mode.rs
+++ b/api/src/quad/streaming_mode.rs
@@ -135,7 +135,8 @@ where
 /// [`Quad`]: quad/trait.Quad.html
 #[macro_export]
 macro_rules! make_scoped_quad_streaming_mode {
-    ($mode: ident, $qt: ident) => {
+    ($(#[$attrs: meta])* $mode: ident, $qt: ident) => {
+        $(#[$attrs])*
         #[derive(Debug)]
         pub struct $mode(std::marker::PhantomData<$qt<'static>>);
         impl $crate::quad::streaming_mode::QuadStreamingMode for $mode {

--- a/api/src/triple/streaming_mode.rs
+++ b/api/src/triple/streaming_mode.rs
@@ -195,7 +195,8 @@ where
 /// [`Triple`]: triple/trait.Triple.html
 #[macro_export]
 macro_rules! make_scoped_triple_streaming_mode {
-    ($mode: ident, $tt: ident) => {
+    ($(#[$attrs: meta])* $mode: ident, $tt: ident) => {
+        $(#[$attrs])*
         #[derive(Debug)]
         pub struct $mode(std::marker::PhantomData<$tt<'static>>);
         impl $crate::triple::streaming_mode::TripleStreamingMode for $mode {

--- a/sophia/src/dataset/indexed.rs
+++ b/sophia/src/dataset/indexed.rs
@@ -21,7 +21,7 @@ pub trait IndexedDataset {
     /// The type used to represent terms internally.
     type Index: Copy + Eq + Hash;
 
-    /// The typed used to represent the term data.
+    /// The type used to hold the term data.
     type TermData: TermData + 'static;
 
     /// Construct a new empty dataset, provisioning for storing `capacity` quads.

--- a/sophia/src/dataset/indexed.rs
+++ b/sophia/src/dataset/indexed.rs
@@ -20,6 +20,8 @@ use sophia_term::*;
 pub trait IndexedDataset {
     /// The type used to represent terms internally.
     type Index: Copy + Eq + Hash;
+
+    /// The typed used to represent the term data.
     type TermData: TermData + 'static;
 
     /// Construct a new empty dataset, provisioning for storing `capacity` quads.

--- a/sophia/src/dataset/inmem/_gspo_wrapper.rs
+++ b/sophia/src/dataset/inmem/_gspo_wrapper.rs
@@ -35,6 +35,8 @@ where
     T: IndexedDataset + Default,
     T::Index: Default,
 {
+    /// Build a new `DatasetWrapper` that indexes quads by graph name,
+    /// then by subject, then by predicate, then by object.
     pub fn new() -> Self {
         Self::default()
     }

--- a/sophia/src/dataset/inmem/_hash_dataset.rs
+++ b/sophia/src/dataset/inmem/_hash_dataset.rs
@@ -37,6 +37,7 @@ where
     I: TermIndexMap,
     I::Index: Hash,
 {
+    /// Build a new dataset, storing its terms in a `TermIndexMap` and its triples in a Hashset.
     pub fn new() -> HashDataset<I> {
         HashDataset {
             terms: I::default(),
@@ -44,11 +45,13 @@ where
         }
     }
 
+    /// Returns the number of quads in the dataset.
     #[inline]
     pub fn len(&self) -> usize {
         self.quads.len()
     }
 
+    /// Checks if the dataset is empty.
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.quads.is_empty()

--- a/sophia/src/dataset/inmem/_ogps_wrapper.rs
+++ b/sophia/src/dataset/inmem/_ogps_wrapper.rs
@@ -34,6 +34,8 @@ where
     T: IndexedDataset + Default,
     T::Index: Default,
 {
+    /// Build a new `DatasetWrapper` that indexes quads by graph name,
+    /// then by object, then by predicate, then by subject.
     pub fn new() -> Self {
         Self::default()
     }

--- a/sophia/src/dataset/inmem/_ogps_wrapper.rs
+++ b/sophia/src/dataset/inmem/_ogps_wrapper.rs
@@ -34,8 +34,8 @@ where
     T: IndexedDataset + Default,
     T::Index: Default,
 {
-    /// Build a new `DatasetWrapper` that indexes quads by graph name,
-    /// then by object, then by predicate, then by subject.
+    /// Build a new `DatasetWrapper` that indexes quads by object,
+    /// then by graph name, then by predicate, then by subject.
     pub fn new() -> Self {
         Self::default()
     }

--- a/sophia/src/graph/indexed.rs
+++ b/sophia/src/graph/indexed.rs
@@ -22,6 +22,8 @@ use sophia_term::*;
 pub trait IndexedGraph {
     /// The type used to represent terms internally.
     type Index: Copy + Eq + Hash;
+
+    /// The type used to represent the term data.
     type TermData: TermData + 'static;
 
     /// Construct a new empty graph, provisioning for storing `capacity` triples.

--- a/sophia/src/graph/indexed.rs
+++ b/sophia/src/graph/indexed.rs
@@ -23,7 +23,7 @@ pub trait IndexedGraph {
     /// The type used to represent terms internally.
     type Index: Copy + Eq + Hash;
 
-    /// The type used to represent the term data.
+    /// The type used to hold the term data.
     type TermData: TermData + 'static;
 
     /// Construct a new empty graph, provisioning for storing `capacity` triples.

--- a/sophia/src/graph/inmem/_hash_graph.rs
+++ b/sophia/src/graph/inmem/_hash_graph.rs
@@ -37,6 +37,8 @@ where
     I: TermIndexMap,
     I::Index: Hash,
 {
+    /// Build a new graph which stores its terms in a `TermIndexMap`, and its
+    /// triples in a `HashSet`.
     pub fn new() -> HashGraph<I> {
         HashGraph {
             terms: I::default(),
@@ -44,10 +46,12 @@ where
         }
     }
 
+    /// Returns the number of triples in the graph.
     pub fn len(&self) -> usize {
         self.triples.len()
     }
 
+    /// Returns whether the graph is empty.
     pub fn is_empty(&self) -> bool {
         self.triples.is_empty()
     }

--- a/sophia/src/graph/inmem/_ops_wrapper.rs
+++ b/sophia/src/graph/inmem/_ops_wrapper.rs
@@ -32,6 +32,8 @@ where
     T: IndexedGraph + Default,
     T::Index: Default,
 {
+    /// Build a `GraphWrapper`, indexing triples by object, then by predicate,
+    /// then by subject.
     pub fn new() -> Self {
         Self::default()
     }

--- a/sophia/src/graph/inmem/_spo_wrapper.rs
+++ b/sophia/src/graph/inmem/_spo_wrapper.rs
@@ -32,6 +32,8 @@ where
     T: IndexedGraph + Default,
     T::Index: Default,
 {
+    /// Build a `GraphWrapper`, indexing triples by subject, then by predicate,
+    /// then by object.
     pub fn new() -> Self {
         Self::default()
     }

--- a/sophia/src/graph/inmem/_term_index_map_u.rs
+++ b/sophia/src/graph/inmem/_term_index_map_u.rs
@@ -43,6 +43,7 @@ where
     I: Unsigned,
     F: TermFactory + Default,
 {
+    /// Build a `TermIndexMap`.
     pub fn new() -> TermIndexMapU<I, F> {
         Self::default()
     }
@@ -167,11 +168,22 @@ where
 /// as an abstraction of all unsigned int types.
 ///
 pub trait Unsigned: Copy + Eq + std::hash::Hash {
+    /// The value zero.
     const ZERO: Self;
+
+    /// The value one.
     const ONE: Self;
+
+    /// Get the value as a `usize`.
     fn as_usize(&self) -> usize;
+
+    /// Construct a value from `usize`.
     fn from_usize(_: usize) -> Self;
+
+    /// Increment the value.
     fn inc(&mut self);
+
+    /// Decrement the value.
     fn dec(&mut self);
 }
 

--- a/sophia/src/lib.rs
+++ b/sophia/src/lib.rs
@@ -63,6 +63,8 @@
 //! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
 
+#![deny(missing_docs)]
+
 pub mod query;
 
 /// This module re-exports symbols from

--- a/sophia/src/parser/gtrig.rs
+++ b/sophia/src/parser/gtrig.rs
@@ -8,6 +8,7 @@ use std::io::BufRead;
 /// TriG parser based on RIO.
 #[derive(Clone, Debug, Default)]
 pub struct GTriGParser {
+    /// The current base IRI.
     pub base: Option<String>,
 }
 

--- a/sophia/src/parser/gtrig.rs
+++ b/sophia/src/parser/gtrig.rs
@@ -8,7 +8,7 @@ use std::io::BufRead;
 /// TriG parser based on RIO.
 #[derive(Clone, Debug, Default)]
 pub struct GTriGParser {
-    /// The current base IRI.
+    /// The base IRI used by this parser to resolve relative IRI-references.
     pub base: Option<String>,
 }
 

--- a/sophia/src/parser/rio_common.rs
+++ b/sophia/src/parser/rio_common.rs
@@ -13,11 +13,11 @@ use sophia_api::triple::streaming_mode::StreamedTriple;
 use sophia_term::literal::convert::AsLiteral;
 use sophia_term::{BoxTerm, RefTerm};
 
-/// TripleSource / QuadSource adapter for RIO TripleParser / QuadParser
+/// TripleSource / QuadSource adapter for RIO TripleParser / QuadParser.
 pub enum StrictRioSource<T, E> {
-    /// A RIO TripleParser / QuadParser
+    /// A RIO TripleParser / QuadParser.
     Parser(T),
-    /// An error in acquiring the RIO TripleParser / QuadParser
+    /// An error in acquiring the RIO TripleParser / QuadParser.
     Error(Option<E>),
 }
 
@@ -157,11 +157,11 @@ where
     }
 }
 
-/// QuadSource adapter for RIO GeneralizedQuadParser
+/// QuadSource adapter for RIO GeneralizedQuadParser.
 pub enum GeneralizedRioSource<T, E> {
-    /// A RIO GeneralizedQuadParser
+    /// A RIO GeneralizedQuadParser.
     Parser(T),
-    /// An error in acquiring the RIO GeneralizedQuadParser
+    /// An error in acquiring the RIO GeneralizedQuadParser.
     Error(Option<E>),
 }
 

--- a/sophia/src/parser/rio_common.rs
+++ b/sophia/src/parser/rio_common.rs
@@ -69,7 +69,11 @@ where
 
 /// A RIO source triple.
 pub type RioSourceTriple<'a> = [RefTerm<'a>; 3];
-sophia_api::make_scoped_triple_streaming_mode!(ScopedRioSourceTriple, RioSourceTriple);
+sophia_api::make_scoped_triple_streaming_mode!(
+    /// A scoped RIO source triple.
+    ScopedRioSourceTriple,
+    RioSourceTriple
+);
 
 impl<T, E> TripleSource for StrictRioSource<T, E>
 where
@@ -109,7 +113,11 @@ where
 
 /// A RIO source quad.
 pub type RioSourceQuad<'a> = ([RefTerm<'a>; 3], Option<RefTerm<'a>>);
-sophia_api::make_scoped_quad_streaming_mode!(ScopedRioSourceQuad, RioSourceQuad);
+sophia_api::make_scoped_quad_streaming_mode!(
+    /// A scoped RIO source quad.
+    ScopedRioSourceQuad,
+    RioSourceQuad
+);
 
 impl<T, E> QuadSource for StrictRioSource<T, E>
 where

--- a/sophia/src/parser/rio_common.rs
+++ b/sophia/src/parser/rio_common.rs
@@ -67,7 +67,7 @@ where
     }
 }
 
-/// A RIO source triple.
+/// A triple produced by a RIO source.
 pub type RioSourceTriple<'a> = [RefTerm<'a>; 3];
 sophia_api::make_scoped_triple_streaming_mode!(
     /// A scoped RIO source triple.

--- a/sophia/src/parser/rio_common.rs
+++ b/sophia/src/parser/rio_common.rs
@@ -15,7 +15,9 @@ use sophia_term::{BoxTerm, RefTerm};
 
 /// TripleSource / QuadSource adapter for RIO TripleParser / QuadParser
 pub enum StrictRioSource<T, E> {
+    /// A RIO TripleParser / QuadParser
     Parser(T),
+    /// An error in acquiring the RIO TripleParser / QuadParser
     Error(Option<E>),
 }
 
@@ -65,6 +67,7 @@ where
     }
 }
 
+/// A RIO source triple.
 pub type RioSourceTriple<'a> = [RefTerm<'a>; 3];
 sophia_api::make_scoped_triple_streaming_mode!(ScopedRioSourceTriple, RioSourceTriple);
 
@@ -104,6 +107,7 @@ where
     }
 }
 
+/// A RIO source quad.
 pub type RioSourceQuad<'a> = ([RefTerm<'a>; 3], Option<RefTerm<'a>>);
 sophia_api::make_scoped_quad_streaming_mode!(ScopedRioSourceQuad, RioSourceQuad);
 
@@ -147,7 +151,9 @@ where
 
 /// QuadSource adapter for RIO GeneralizedQuadParser
 pub enum GeneralizedRioSource<T, E> {
+    /// A RIO GeneralizedQuadParser
     Parser(T),
+    /// An error in acquiring the RIO GeneralizedQuadParser
     Error(Option<E>),
 }
 

--- a/sophia/src/parser/trig.rs
+++ b/sophia/src/parser/trig.rs
@@ -8,7 +8,7 @@ use std::io::BufRead;
 /// TriG parser based on RIO.
 #[derive(Clone, Debug, Default)]
 pub struct TriGParser {
-    /// The current base IRI.
+    /// The base IRI used by this parser to resolve relative IRI-references.
     pub base: Option<String>,
 }
 

--- a/sophia/src/parser/trig.rs
+++ b/sophia/src/parser/trig.rs
@@ -8,6 +8,7 @@ use std::io::BufRead;
 /// TriG parser based on RIO.
 #[derive(Clone, Debug, Default)]
 pub struct TriGParser {
+    /// The current base IRI.
     pub base: Option<String>,
 }
 

--- a/sophia/src/parser/turtle.rs
+++ b/sophia/src/parser/turtle.rs
@@ -26,7 +26,7 @@ impl<B: BufRead> TripleParser<B> for TurtleParser {
     }
 }
 
-/// A wrapper around [`rio_turtle::TurtleError`] the implements [`WithLocation`].
+/// A wrapper around [`rio_turtle::TurtleError`] that implements [`WithLocation`].
 ///
 /// [`rio_turtle::TurtleError`]: ../../../rio_turtle/struct.TurtleError.html
 /// [`WithLocation`]: ../trait.WithLocation.html

--- a/sophia/src/parser/turtle.rs
+++ b/sophia/src/parser/turtle.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 /// Turtle parser based on RIO.
 #[derive(Clone, Debug, Default)]
 pub struct TurtleParser {
-    /// The current base IRI.
+    /// The base IRI used by this parser to resolve relative IRI-references.
     pub base: Option<String>,
 }
 

--- a/sophia/src/parser/turtle.rs
+++ b/sophia/src/parser/turtle.rs
@@ -11,6 +11,7 @@ use thiserror::Error;
 /// Turtle parser based on RIO.
 #[derive(Clone, Debug, Default)]
 pub struct TurtleParser {
+    /// The current base IRI.
     pub base: Option<String>,
 }
 
@@ -25,6 +26,10 @@ impl<B: BufRead> TripleParser<B> for TurtleParser {
     }
 }
 
+/// A wrapper around [`rio_turtle::TurtleError`] the implements [`WithLocation`].
+///
+/// [`rio_turtle::TurtleError`]: ../../../rio_turtle/struct.TurtleError.html
+/// [`WithLocation`]: ../trait.WithLocation.html
 #[derive(Debug, Error)]
 #[error("{0}")]
 pub struct SophiaTurtleError(pub TurtleError);

--- a/sophia/src/parser/xml.rs
+++ b/sophia/src/parser/xml.rs
@@ -12,7 +12,7 @@ use crate::parser::TripleParser;
 /// N-Triples parser based on RIO.
 #[derive(Clone, Debug, Default)]
 pub struct RdfXmlParser {
-    /// The base IRI.
+    /// The base IRI used by this parser to resolve relative IRI-references.
     pub base: Option<String>,
 }
 

--- a/sophia/src/parser/xml.rs
+++ b/sophia/src/parser/xml.rs
@@ -12,6 +12,7 @@ use crate::parser::TripleParser;
 /// N-Triples parser based on RIO.
 #[derive(Clone, Debug, Default)]
 pub struct RdfXmlParser {
+    /// The base IRI.
     pub base: Option<String>,
 }
 

--- a/sophia/src/parser/xml_legacy.rs
+++ b/sophia/src/parser/xml_legacy.rs
@@ -99,7 +99,7 @@ pub struct RdfXmlParser {
 }
 
 impl RdfXmlParser {
-    /// Build a new RDF XML parser with the given config.
+    /// Build a new RDF/XML parser with the given config.
     pub fn with_base(base: &str) -> Result<Self> {
         match Url::parse(base) {
             Ok(url) => Ok(Self { base: Some(url) }),

--- a/sophia/src/parser/xml_legacy.rs
+++ b/sophia/src/parser/xml_legacy.rs
@@ -99,6 +99,7 @@ pub struct RdfXmlParser {
 }
 
 impl RdfXmlParser {
+    /// Build a new RDF XML parser with the given config.
     pub fn with_base(base: &str) -> Result<Self> {
         match Url::parse(base) {
             Ok(url) => Ok(Self { base: Some(url) }),

--- a/sophia/src/parser/xml_legacy/_error.rs
+++ b/sophia/src/parser/xml_legacy/_error.rs
@@ -3,6 +3,8 @@ use sophia_api::parser::{Location, Position, WithLocation};
 use std::error::Error;
 use std::io::BufRead;
 
+/// The `Result` type used in the module
+/// [`sophia::parser::xml_legacy`](index.html).
 pub type Result<T, E = XmlParserError> = std::result::Result<T, E>;
 
 /// This error is raised at parsing RDF/XML documents.
@@ -11,15 +13,23 @@ pub enum XmlParserError {
     /// Errors raised by malformed XML.
     #[error("Invalid XML: {source} at {location}")]
     Xml {
+        /// The source of the error raised by malformed XML.
         source: quick_xml::Error,
+
+        /// The location of the error raised by malformed XML.
         location: Location,
     },
+
     /// Errors raised by violating the RDF/XML specifications.
     #[error("Invalid RDF/XML: {source} at {location}")]
     InterpretRdf {
+        /// The source of the error raised by violating the RDF/XML specifications.
         source: RdfError,
+
+        /// The location of the error raised by violating the RDF/XML specifications.
         location: Location,
     },
+
     /// Errors happening at setup of the parser.
     #[error("Error at parser setup: {0}")]
     Setup(#[from] RdfError),
@@ -38,6 +48,7 @@ impl WithLocation for XmlParserError {
 
 /// An error which can be enriched with location information.
 pub trait LocatableError<L>: Error {
+    /// The error type used internally by this trait.
     type WithLocation: WithLocation + Error;
 
     /// Add location information to this error.
@@ -83,34 +94,71 @@ where
 /// _Note:_ Errors of malformed XML are not handled by this type.
 #[derive(Debug, thiserror::Error)]
 pub enum RdfError {
+    /// An ID occurred at least twice.
     #[error("ID {0} occured at least twice")]
     DuplicateId(String),
+
+    /// A namespace is unknown.
     #[error("The namespace {0} is unknown")]
     UnknownNamespace(String),
+
+    /// A node name is invalid.
     #[error("The name {0} is invalid for nodes in RDF/XML")]
     InvalidNodeName(String),
+
+    /// A property name is invalid.
     #[error("The name {0} is invalid for properties in RDF/XML")]
     InvalidPropertyName(String),
+
+    /// An attribute name is invalid.
     #[error("The name {0} is invalid for attributes in RDF/XML")]
     InvalidAttribute(String),
+
+    /// An XML name is invalid.
     #[error("{0} is not a valid XML name")]
     InvalidXmlName(String),
+
+    /// A `parseType` is invalid.
+    /// It can only have one of `rdf:ID`, `rdf:nodeID` and `rdf:about` at the same time.
     #[error("The `parseType={0}` is not a valid in this context")]
     InvalidParseType(String),
+
+    /// A subject violates the restriction that it can only have one of
+    /// `rdf:ID`, `rdf:nodeID` and `rdf:about` at the same time.
     #[error("Can only have one of `rdf:ID`, `rdf:nodeID` and `rdf:about` at the same time")]
     AmbiguousSubject,
+
+    /// An unexpected XML event.
     #[error("Unexpected XML event: expected {expected}, found {found} instead")]
-    UnexpectedEvent { expected: String, found: String },
+    UnexpectedEvent {
+        /// What was expected in an unexpected XML event.
+        expected: String,
+
+        /// What was found in an unexpected XML event.
+        found: String,
+    },
+
+    /// The Document does not define a base IRI.
     #[error("Document does not define a base IRI. Required to expand `{0}`")]
     NoBaseIri(String),
+
+    /// An invalid prefix (`_`).
     #[error("Prefixes must not be `_`")]
     InvalidPrefixBlank,
+
+    /// An invalid RDF-term.
     #[error("Invalid RDF-term: {0}")]
     InvalidRdfTerm(#[from] sophia_term::TermError),
+
+    /// An invalid URL.
     #[error("Invalid Url: {0}")]
     InvalidUrl(#[from] url::ParseError),
+
+    /// An invalid base IRI.
     #[error("The given base IRI `{0}` is not a valid IRI")]
     InvalidBaseIri(String),
+
+    /// An invalid IRI.
     #[error("Invalid IRI: {0}")]
     InvalidIri(#[from] sophia_iri::error::InvalidIri),
 }

--- a/sophia/src/serializer/nq.rs
+++ b/sophia/src/serializer/nq.rs
@@ -21,13 +21,14 @@ pub struct NqConfig {
 }
 
 impl NqConfig {
+    /// Set the ascii configuration.
     pub fn set_ascii(&mut self, ascii: bool) -> &mut Self {
         self.ascii = ascii;
         self
     }
 }
 
-// N-Quads serializer.
+/// N-Quads serializer.
 pub struct NqSerializer<W> {
     config: NqConfig,
     write: W,

--- a/sophia/src/serializer/nt.rs
+++ b/sophia/src/serializer/nt.rs
@@ -23,13 +23,14 @@ pub struct NtConfig {
 }
 
 impl NtConfig {
+    /// Set the ascii configuration.
     pub fn set_ascii(&mut self, ascii: bool) -> &mut Self {
         self.ascii = ascii;
         self
     }
 }
 
-// N-Triples serializer.
+/// N-Triples serializer.
 pub struct NtSerializer<W> {
     config: NtConfig,
     write: W,


### PR DESCRIPTION
I added documentation to most public elements in `sophia/`, using
the method described in the issue (#44) of adding `#![deny(missing_docs)]`
to `sophia/src/lib.rs`.

~2 doc comments are missing:~
- ~[sophia_api::make_scoped_triple_streaming_mode!(ScopedRioSourceTriple, RioSourceTriple);](https://github.com/pchampin/sophia_rs/blob/master/sophia/src/parser/rio_common.rs#L69)~
- ~[sophia_api::make_scoped_quad_streaming_mode!(ScopedRioSourceQuad, RioSourceQuad);](https://github.com/pchampin/sophia_rs/blob/master/sophia/src/parser/rio_common.rs#L108)~

~I don't know how to add comments to the macro-created types.~

I found out that it's possible to add doc comments to macros (https://stackoverflow.com/a/33999625/4696215) and updated the relevant macros accordingly in a separate commit.