### PR TITLE
Fix unresolved doc links in jsonld/src/serializer.rs

### DIFF
--- a/jsonld/src/serializer.rs
+++ b/jsonld/src/serializer.rs
@@ -67,13 +67,13 @@ where
 
 pub type Jsonifier = JsonLdSerializer<JsonTarget>;
 
-/// This type is just a placeholder [`JsonLdSerialiser`]
+/// This type is just a placeholder [`JsonLdSerializer`]
 /// targetting a `JsonValue`.
 /// See [`new_jsonifier`] and [`new_jsonifier_with_config`].
 ///
-/// [`JsonLdSerializer`](./struct.JsonLdSerializer.html)
-/// [`new_jsonifier`](./struct.JsonLdSerializer.html#method.new_jsonifier)
-/// [`new_jsonifier_with_config`](./struct.JsonLdSerializer.html#method.new_jsonifier_with_config)
+/// [`JsonLdSerializer`]: struct.JsonLdSerializer.html
+/// [`new_jsonifier`]: struct.JsonLdSerializer.html#method.new_jsonifier
+/// [`new_jsonifier_with_config`]: struct.JsonLdSerializer.html#method.new_jsonifier_with_config
 #[derive(Clone, Debug)]
 pub struct JsonTarget(JsonValue);
 


### PR DESCRIPTION
The 3 links in the doc comment of
`sophia_jsonld::serializer::jsonTarget` were emitting `unresolved
link` warnings.

The broken links can be seen in: https://docs.rs/sophia_jsonld/0.6.2/sophia_jsonld/serializer/struct.JsonTarget.html

There was a typo (`JsonLdSerialiser` instead of `JsonLdSerializer`)
and the links were specified with the wrong syntax:
`[...](...)` instead of `[...]: ...`

This is related to #44 (broken links rather than missing docs).