### PR TITLE
Improve doc coverage for `sophia_jsonld`

### DIFF
--- a/jsonld/src/config.rs
+++ b/jsonld/src/config.rs
@@ -1,43 +1,83 @@
+//! JSON-LD serializer configuration.
+
 /// JSON-LD serializer configuration.
 #[derive(Clone, Debug, Default)]
 pub struct JsonLdConfig {
+    /// A JSON-LD option determining how value objects containing
+    /// a base direction are transformed to and from RDF.
+    ///
+    /// [`rdfDirection`]: https://www.w3.org/TR/json-ld11-api/#dom-jsonldoptions-rdfdirection
     pub rdf_direction: Option<RdfDirectionMode>,
+
+    /// The number of spaces to indent new blocks with.
     pub spaces: u16,
+
+    /// The JSON-LD spec version, which can be [`JSON-LD 1.0`] or [`JSON-LD 1.1`].
+    ///
+    /// [`JSON-LD 1.0`]: https://json-ld.org/spec/FCGS/json-ld-syntax/20130222/
+    /// [`JSON-LD 1.1`]: https://www.w3.org/TR/json-ld11/
     pub spec_version: JsonLdSpecVersion,
+
+    /// The [`useNativeTypes`] flag, which causes the `Serialize RDF as JSON-LD Algorithm`
+    /// to use native JSON values in value objects avoiding the need for an explicit `@type`.
+    ///
+    /// [`useNativeTypes`]: https://www.w3.org/TR/json-ld11-api/#dom-jsonldoptions-usenativetypes
     pub use_native_types: bool,
+
+    /// The [`useRdfType`] flag, which enables special rules for the `Serialize RDF as JSON-LD
+    /// Algorithm` causing `rdf:type` properties to be kept as IRIs in the output, rather than use
+    /// `@type`.
+    ///
+    /// [`useRdfType`]: https://www.w3.org/TR/json-ld11-api/#dom-jsonldoptions-userdftype
     pub use_rdf_type: bool,
 }
 
 impl JsonLdConfig {
+    /// Build a new JSON-LD serializer configuration.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Set the number of spaces to indent new blocks with.
     pub fn spaces(mut self, spaces: u16) -> Self {
         self.spaces = spaces;
         self
     }
 
+    /// Set the JSON-LD spec version.
     pub fn spec_version(mut self, version: JsonLdSpecVersion) -> Self {
         self.spec_version = version;
         self
     }
 
+    /// Set the [`useNativeTypes`] flag.
+    ///
+    /// [`useNativeTypes`]: https://www.w3.org/TR/json-ld11-api/#dom-jsonldoptions-usenativetypes
     pub fn use_native_types(mut self, flag: bool) -> Self {
         self.use_native_types = flag;
         self
     }
 
+    /// Set the [`useRdfType`] flag.
+    ///
+    /// [`useRdfType`]: https://www.w3.org/TR/json-ld11-api/#dom-jsonldoptions-userdftype
     pub fn use_rdf_type(mut self, flag: bool) -> Self {
         self.use_rdf_type = flag;
         self
     }
 }
 
+/// The JSON-LD spec version, which can be [`JSON-LD 1.0`] or [`JSON-LD 1.1`].
+///
+/// [`JSON-LD 1.0`]: https://json-ld.org/spec/FCGS/json-ld-syntax/20130222/
+/// [`JSON-LD 1.1`]: https://www.w3.org/TR/json-ld11/
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 pub enum JsonLdSpecVersion {
+    /// [`JSON-LD 1.0`](https://json-ld.org/spec/FCGS/json-ld-syntax/20130222/)
     JsonLd10,
+
+    /// [`JSON-LD 1.1`](https://www.w3.org/TR/json-ld11/)
     JsonLd11,
 }
 
@@ -47,9 +87,22 @@ impl Default for JsonLdSpecVersion {
     }
 }
 
+/// A JSON-LD option determining how value objects containing
+/// a base direction are transformed to and from RDF.
+///
+/// [`rdfDirection`]: https://www.w3.org/TR/json-ld11-api/#dom-jsonldoptions-rdfdirection
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum RdfDirectionMode {
+    /// The `i18n-datatype` setting of `rdfDirection` determines that an `RDF literal` is generated
+    /// using a datatype IRI based on `https://www.w3.org/ns/i18n#` with both the `language tag`
+    /// (if present) and `base direction` encoded. When transforming from RDF, this datatype is
+    /// decoded to create a `value object` containing `@language` (if present) and `@direction`.
     I18nDatatype,
+
+    /// The `compound-literal` setting of `rdfDirection` determines that a `blank node` is emitted
+    /// instead of a literal, where the blank node is the subject of `rdf:value`, `rdf:direction`,
+    /// and `rdf:language` (if present) properties. When transforming from RDF, this object is
+    /// decoded to create a `value object` containing `@language` (if present) and `@direction`.
     CompoundLiteral,
 }

--- a/jsonld/src/error.rs
+++ b/jsonld/src/error.rs
@@ -1,13 +1,20 @@
+//! JSON-LD errors.
+
 use crate::config::JsonLdSpecVersion;
 
 /// JSON-LD error
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum JsonLdError {
+    /// An invalid JSON literal.
     #[error("invalid JSON literal: {0}")]
     InvalidJsonLiteral(#[from] json::Error),
+
+    /// An IO error.
     #[error("IO Error: {0}")]
     IOError(#[from] std::io::Error),
+
+    /// An unsupported JSON-LD version
     #[error("unsupported version: {0:?}")]
     UnsupportedVersion(JsonLdSpecVersion),
 }

--- a/jsonld/src/lib.rs
+++ b/jsonld/src/lib.rs
@@ -7,6 +7,8 @@
 //! [JSON-LD]: https://www.w3.org/TR/json-ld11/
 //! [expanded document form]: https://www.w3.org/TR/json-ld11/#expanded-document-form
 
+#![deny(missing_docs)]
+
 pub mod config;
 pub use config::*;
 pub mod error;

--- a/jsonld/src/serializer.rs
+++ b/jsonld/src/serializer.rs
@@ -67,13 +67,13 @@ where
 
 pub type Jsonifier = JsonLdSerializer<JsonTarget>;
 
-/// This type is just a placeholder [`JsonLdSerialiser`]
+/// This type is just a placeholder [`JsonLdSerializer`]
 /// targetting a `JsonValue`.
 /// See [`new_jsonifier`] and [`new_jsonifier_with_config`].
 ///
-/// [`JsonLdSerializer`](./struct.JsonLdSerializer.html)
-/// [`new_jsonifier`](./struct.JsonLdSerializer.html#method.new_jsonifier)
-/// [`new_jsonifier_with_config`](./struct.JsonLdSerializer.html#method.new_jsonifier_with_config)
+/// [`JsonLdSerializer`]: struct.JsonLdSerializer.html
+/// [`new_jsonifier`]: struct.JsonLdSerializer.html#method.new_jsonifier
+/// [`new_jsonifier_with_config`]: struct.JsonLdSerializer.html#method.new_jsonifier_with_config
 #[derive(Clone, Debug)]
 pub struct JsonTarget(JsonValue);
 

--- a/jsonld/src/serializer.rs
+++ b/jsonld/src/serializer.rs
@@ -1,3 +1,8 @@
+//! A JSON-LD serializer implementing the
+//! [`Serialize RDF as JSON-LD Algorithm`].
+//!
+//! [`Serialize RDF as JSON-LD Algorithm`]: https://www.w3.org/TR/json-ld11-api/#serialize-rdf-as-json-ld-algorithm
+
 use crate::config::*;
 use crate::error::*;
 use json::JsonValue;
@@ -10,6 +15,7 @@ mod rdf_object;
 #[cfg(test)]
 mod test;
 
+/// A JSON-LD serializer.
 pub struct JsonLdSerializer<W> {
     config: JsonLdConfig,
     target: W,
@@ -65,6 +71,10 @@ where
     }
 }
 
+/// A utility type alias of [`JsonLdSerializer`] with `[JsonTarget]` as its target.
+///
+/// [`JsonLdSerializer`]: struct.JsonLdSerializer.html
+/// [`JsonTarget`]: struct.JsonTarget.html
 pub type Jsonifier = JsonLdSerializer<JsonTarget>;
 
 /// This type is just a placeholder [`JsonLdSerializer`]
@@ -108,6 +118,9 @@ impl QuadSerializer for Jsonifier {
     }
 }
 
+/// A utility type alias representing a [`JsonLdSerializer`] which targets a string.
+///
+/// [`JsonLdSerializer`]: struct.JsonLdSerializer.html
 pub type JsonLdStringifier = JsonLdSerializer<Vec<u8>>;
 
 impl JsonLdStringifier {

--- a/jsonld/src/test_util.rs
+++ b/jsonld/src/test_util.rs
@@ -1,5 +1,7 @@
 //! Utility types and functions for testing JSON-LD
 
+#![allow(missing_docs)]
+
 use crate::config::*;
 use crate::error::*;
 use crate::serializer::Jsonifier;


### PR DESCRIPTION
- Add `#![deny(missing_docs)]` in `jsonld/src/lib.rs`
- Add `#![allow(missing_docs)]` in `jsonld/src/test_util.rs`
- Add missing doc comments

Related to #44

It includes the changes in #85 (fixing unresolved links).