### PR TITLE
Generic API for SPARQL support

### DIFF
--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -39,5 +39,6 @@ pub mod parser;
 pub mod prefix;
 pub mod quad;
 pub mod serializer;
+pub mod sparql;
 pub mod term;
 pub mod triple;

--- a/api/src/sparql.rs
+++ b/api/src/sparql.rs
@@ -4,7 +4,7 @@
 //!
 //! These traits are deliberately very generic.
 //! Specific implementations may have additional features, such as:
-//! 
+//!
 //! - preparing a query for multiple use;
 //! - setting default values for `BASE`, `PREFIX`, `FROM`, `FROM NAMED` directives,
 //!   before parsing query string;
@@ -26,17 +26,16 @@ pub trait SparqlDataset: Dataset {
     type SparqlError: Error + 'static;
 
     /// Parse and immediately execute `query`
-    fn execute<'p, P>(&self, query: &str) -> Result<Self::Result, Self::SparqlError>
+    fn query<'p, P>(&self, query: &str) -> Result<Self::Result, Self::SparqlError>
     where
-        P: PrefixMap<'p> + ?Sized,
-    ;
+        P: PrefixMap<'p> + ?Sized;
 }
 
 /// The result of executing a SPARQL query.
 pub trait SparqlResult {
     type Term: TTerm;
     /// The type of iterator returned if the query was a SELECT.
-    type Bindings: Iterator<Item=Vec<Option<Self::Term>>>;
+    type Bindings: Iterator<Item = Vec<Option<Self::Term>>>;
     /// The type of graph returned if the query was a CONSTRUCT or DESCRIBE.
     type Graph: Graph;
 
@@ -53,6 +52,7 @@ pub trait SparqlResult {
 }
 
 /// Different kinds of SPARQL results
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SparqlResultKind {
     /// Result of a SELECT query
     Bindings,

--- a/api/src/sparql.rs
+++ b/api/src/sparql.rs
@@ -1,0 +1,63 @@
+//! Common traits for working with [SPARQL](https://www.w3.org/TR/sparql11-query/).
+//!
+//! # Design rationale
+//!
+//! These traits are deliberately very generic.
+//! Specific implementations may have additional features, such as:
+//! 
+//! - preparing a query for multiple use;
+//! - setting default values for `BASE`, `PREFIX`, `FROM`, `FROM NAMED` directives,
+//!   before parsing query string;
+//! - pre-binding variables before evaluating query;
+//! - etc...
+//!
+//! However, we do not want to impose these feature, or any subset thereof,
+//! to all implementation of Sophia.
+
+use crate::dataset::Dataset;
+use crate::graph::Graph;
+use crate::prefix::PrefixMap;
+use crate::term::TTerm;
+use std::error::Error;
+
+/// A dataset that can be queried with SPARQL.
+pub trait SparqlDataset: Dataset {
+    type Result: SparqlResult;
+    type SparqlError: Error + 'static;
+
+    /// Parse and immediately execute `query`
+    fn execute<'p, P>(&self, query: &str) -> Result<Self::Result, Self::SparqlError>
+    where
+        P: PrefixMap<'p> + ?Sized,
+    ;
+}
+
+/// The result of executing a SPARQL query.
+pub trait SparqlResult {
+    type Term: TTerm;
+    /// The type of iterator returned if the query was a SELECT.
+    type Bindings: Iterator<Item=Vec<Option<Self::Term>>>;
+    /// The type of graph returned if the query was a CONSTRUCT or DESCRIBE.
+    type Graph: Graph;
+
+    /// The kind of this result (depends on the type of query)
+    fn kind(&self) -> SparqlResultKind;
+    /// If the query was a SELECT, the list of selected variable names
+    fn variables(&self) -> Option<Vec<String>>;
+    /// If the query was a SELECT, an iterator over all the solutions
+    fn bindings(self) -> Option<Self::Bindings>;
+    /// If the query was an ASK, the boolean result
+    fn boolean(&self) -> Option<bool>;
+    /// If the query was a CONSTRUCT or DESCRIBE, the resulting graph
+    fn graph(&self) -> Option<Self::Graph>;
+}
+
+/// Different kinds of SPARQL results
+pub enum SparqlResultKind {
+    /// Result of a SELECT query
+    Bindings,
+    /// Result of an ASK query
+    Boolean,
+    /// Result of a CONSTRUCT or DESCRIBE query
+    Graph,
+}

--- a/api/src/sparql.rs
+++ b/api/src/sparql.rs
@@ -16,7 +16,6 @@
 
 use crate::dataset::Dataset;
 use crate::graph::Graph;
-use crate::prefix::PrefixMap;
 use crate::term::TTerm;
 use std::error::Error;
 
@@ -26,9 +25,7 @@ pub trait SparqlDataset: Dataset {
     type SparqlError: Error + 'static;
 
     /// Parse and immediately execute `query`
-    fn query<'p, P>(&self, query: &str) -> Result<Self::Result, Self::SparqlError>
-    where
-        P: PrefixMap<'p> + ?Sized;
+    fn query(&self, query: &str) -> Result<Self::Result, Self::SparqlError>;
 }
 
 /// The result of executing a SPARQL query.


### PR DESCRIPTION
This addresses #19.

This proposal is über-minimalistic compared to what I suggested initially, but I realized that *generic* SPARQL support is a huge can of worm (see the comment at the top of the `sparql.rs` file).

So decided to go for the least common denominator. The drawback is that anyone requiring (even slightly) advanced SPARQL support will need to rely on implementation specific methods. But I still think that this minimal API has value for interoperability.

Any comment welcome.