### PR TITLE
Use '&dyn TTerm' to access entries in a 'HashSet'

### DIFF
--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -32,4 +32,5 @@ lazy_static = { version = "1.4.0", optional = true }
 [dev-dependencies]
 lazy_static = { version = "1.4.0" }
 sophia_iri = { version = "0.6.2", path = "../iri", features = ["test_data"] }
+sophia_term = { version = "0.6.2", path = "../term" }
 test-case = "1.0.0"

--- a/api/src/term/_dyn_term.rs
+++ b/api/src/term/_dyn_term.rs
@@ -1,37 +1,43 @@
-//! This module is transparently re-exported by its parent `lib`.
+//! Implementations on trait objects of `TTerm`.
+//!
+//! The `'a` lifetimes are required because Rust assumes by default that each
+//! `dyn TTerm` instance is actually `dyn TTerm + 'static` so for example
+//! without the `'a` Rust requires a `'static` borrow if we want to calculate
+//! the hash of a `dyn TTerm` object.
+
 use std::cmp::Ordering;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::hash::{Hash, Hasher};
 
 use super::*;
 
-impl PartialEq for dyn TTerm {
-    fn eq(&self, other: &dyn TTerm) -> bool {
+impl<'a> PartialEq for dyn TTerm + 'a {
+    fn eq(&self, other: &(dyn TTerm + 'a)) -> bool {
         term_eq(self, other)
     }
 }
 
-impl Eq for dyn TTerm {}
+impl<'a> Eq for dyn TTerm + 'a {}
 
-impl PartialOrd for dyn TTerm {
-    fn partial_cmp(&self, other: &dyn TTerm) -> Option<Ordering> {
+impl<'a> PartialOrd for dyn TTerm + 'a {
+    fn partial_cmp(&self, other: &(dyn TTerm + 'a)) -> Option<Ordering> {
         Some(term_cmp(self, other))
     }
 }
 
-impl Ord for dyn TTerm {
-    fn cmp(&self, other: &dyn TTerm) -> Ordering {
+impl<'a> Ord for dyn TTerm + 'a {
+    fn cmp(&self, other: &(dyn TTerm + 'a)) -> Ordering {
         term_cmp(self, other)
     }
 }
 
-impl Hash for dyn TTerm {
+impl<'a> Hash for dyn TTerm + 'a {
     fn hash<H: Hasher>(&self, state: &mut H) {
         term_hash(self, state)
     }
 }
 
-impl Display for dyn TTerm {
+impl<'a> Display for dyn TTerm + 'a {
     fn fmt(&self, fmt: &mut Formatter) -> FmtResult {
         term_format(self, fmt)
     }

--- a/api/src/term/simple_iri.rs
+++ b/api/src/term/simple_iri.rs
@@ -3,6 +3,7 @@
 use super::*;
 use sophia_iri::error::{InvalidIri, Result};
 use sophia_iri::is_valid_suffixed_iri_ref;
+use std::borrow::Borrow;
 use std::fmt;
 use std::hash;
 
@@ -77,5 +78,11 @@ where
 impl<'a> hash::Hash for SimpleIri<'a> {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
         term_hash(self, state)
+    }
+}
+
+impl<'a> Borrow<dyn TTerm + 'a> for SimpleIri<'a> {
+    fn borrow(&self) -> &(dyn TTerm + 'a) {
+        self as _
     }
 }

--- a/term/src/blank_node.rs
+++ b/term/src/blank_node.rs
@@ -272,6 +272,12 @@ where
     }
 }
 
+impl<'a, TD: TermData + 'a> std::borrow::Borrow<dyn TTerm + 'a> for BlankNode<TD> {
+    fn borrow(&self) -> &(dyn TTerm + 'a) {
+        self
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/term/src/iri.rs
+++ b/term/src/iri.rs
@@ -630,6 +630,12 @@ where
     }
 }
 
+impl<'a, TD: TermData + 'a> std::borrow::Borrow<dyn TTerm + 'a> for Iri<TD> {
+    fn borrow(&self) -> &(dyn TTerm + 'a) {
+        self
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/term/src/lib.rs
+++ b/term/src/lib.rs
@@ -51,6 +51,7 @@ use sophia_api::term::{
     term_cmp, term_eq, term_format, term_hash, term_to_string, CopyTerm, RawValue, SimpleIri,
     TTerm, TermKind, TryCopyTerm,
 };
+use std::borrow::Borrow;
 use std::convert::TryInto;
 use std::fmt::Debug;
 use std::hash::{Hash, Hasher};
@@ -561,6 +562,12 @@ where
             TermKind::BlankNode => Term::BNode(BlankNode::new_unchecked(v.0)),
             TermKind::Variable => Term::Variable(Variable::new_unchecked(v.0)),
         }
+    }
+}
+
+impl<'a, TD: TermData + 'a> Borrow<dyn TTerm + 'a> for Term<TD> {
+    fn borrow(&self) -> &(dyn TTerm + 'a) {
+        self as _
     }
 }
 

--- a/term/src/literal.rs
+++ b/term/src/literal.rs
@@ -427,6 +427,12 @@ where
     }
 }
 
+impl<'a, TD: TermData + 'a> std::borrow::Borrow<dyn TTerm + 'a> for Literal<TD> {
+    fn borrow(&self) -> &(dyn TTerm + 'a) {
+        self
+    }
+}
+
 fn fmt_quoted_string<W: fmt::Write>(w: &mut W, txt: &str) -> fmt::Result {
     let mut cut = txt.len();
     let mut cutchar = '\0';

--- a/term/src/test.rs
+++ b/term/src/test.rs
@@ -2,6 +2,23 @@ use super::Term::*;
 use super::*;
 use sophia_api::ns::xsd;
 use sophia_api::term::CopiableTerm;
+use sophia_api::term::SimpleIri;
+use std::collections::HashSet;
+
+#[test]
+fn term_map() -> Result<(), Box<dyn std::error::Error>> {
+    let t: Term<String> = Term::new_iri("http://example.com/test")?;
+    let mut map = HashSet::new();
+    map.insert(t);
+
+    let ns = "http://example.com/";
+    let sf = "test";
+    let iri = SimpleIri::new(ns, Some(sf))?;
+    let iri = iri.as_dyn();
+    let get = map.get(iri);
+    assert!(get.is_some());
+    Ok(())
+}
 
 fn h<H: std::hash::Hash>(x: &H) -> u64 {
     let mut hasher = std::collections::hash_map::DefaultHasher::new();

--- a/term/src/test.rs
+++ b/term/src/test.rs
@@ -2,19 +2,6 @@ use super::Term::*;
 use super::*;
 use sophia_api::ns::xsd;
 use sophia_api::term::CopiableTerm;
-use sophia_api::term::SimpleIri;
-use std::collections::HashSet;
-
-#[test]
-fn term_map() -> Result<(), Box<dyn std::error::Error>> {
-    let t: Term<String> = Term::new_iri("http://example.com/test")?;
-    let mut map = HashSet::new();
-    map.insert(t);
-
-    let iri = SimpleIri::new("http://example.com/", Some("test"))?;
-    assert!(map.get(iri.as_dyn()).is_some());
-    Ok(())
-}
 
 fn h<H: std::hash::Hash>(x: &H) -> u64 {
     let mut hasher = std::collections::hash_map::DefaultHasher::new();

--- a/term/src/test.rs
+++ b/term/src/test.rs
@@ -11,12 +11,8 @@ fn term_map() -> Result<(), Box<dyn std::error::Error>> {
     let mut map = HashSet::new();
     map.insert(t);
 
-    let ns = "http://example.com/";
-    let sf = "test";
-    let iri = SimpleIri::new(ns, Some(sf))?;
-    let iri = iri.as_dyn();
-    let get = map.get(iri);
-    assert!(get.is_some());
+    let iri = SimpleIri::new("http://example.com/", Some("test"))?;
+    assert!(map.get(iri.as_dyn()).is_some());
     Ok(())
 }
 

--- a/term/src/variable.rs
+++ b/term/src/variable.rs
@@ -261,6 +261,12 @@ where
     }
 }
 
+impl<'a, TD: TermData + 'a> std::borrow::Borrow<dyn TTerm + 'a> for Variable<TD> {
+    fn borrow(&self) -> &(dyn TTerm + 'a) {
+        self
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;


### PR DESCRIPTION
This PR adds implementations to `Term` and `dyn TTerm` so that it is now possible to get values from a `HashSet<Term<TD>>` (or `HashMap`) by using `&dyn TTerm` references, e.g.:

```rust
fn main() -> Result<(), Box<dyn std::error::Error>> {
    let t: Term<String> = Term::new_iri("http://example.com/test")?;
    let mut map = HashSet::new();
    map.insert(t);

    let iri = SimpleIri::new("http://example.com/", Some("test"))?;
    assert!(map.get(iri.as_dyn()).is_some());
    Ok(())
}
```

This also works on other implementation of `TTerm` as long as they implement `Borrow<dyn TTerm + 'a>`. However, the contract of `Borrow` requires that each type that implements the `Borrow` trait has an equivalent implementation of `Hash` and `Eq` to the one of `dyn TTerm`, i.e. they must use the `term_hash()` and `term_eq()` functions. So this is not desirable for all implementors of `TTerm`.