### PR TITLE
Inline `sophia` documentation for reexported modules

### DIFF
--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -55,7 +55,6 @@ pub mod graph;
 pub mod ns;
 pub mod parser;
 pub mod prefix;
-#[doc(hidden)]
 pub mod prelude;
 pub mod quad;
 pub mod serializer;

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -55,6 +55,7 @@ pub mod graph;
 pub mod ns;
 pub mod parser;
 pub mod prefix;
+#[doc(hidden)]
 pub mod prelude;
 pub mod quad;
 pub mod serializer;

--- a/sophia/src/lib.rs
+++ b/sophia/src/lib.rs
@@ -35,13 +35,16 @@ pub use sophia_iri as iri;
 #[doc(inline)]
 pub use sophia_isomorphism as isomorphism;
 #[cfg(feature = "jsonld")]
+#[doc(inline)]
 pub use sophia_jsonld as jsonld;
 #[doc(inline)]
 pub use sophia_resource as resource;
 #[doc(inline)]
 pub use sophia_term as term;
+#[doc(inline)]
 pub use sophia_turtle as turtle;
 #[cfg(feature = "xml")]
+#[doc(inline)]
 pub use sophia_xml as xml;
 
 /// Including tests from all code snippets in the book

--- a/sophia/src/lib.rs
+++ b/sophia/src/lib.rs
@@ -9,7 +9,7 @@
 //! * [`inmem`]
 //! * [`iri`]
 //! * [`isomorphism`]
-//! * [`jsonld`]
+//! * [`jsonld`] (with the `jsonld` feature enabled)
 //! * [`resource`]
 //! * [`turtle`]
 //! * [`term`]

--- a/sophia/src/lib.rs
+++ b/sophia/src/lib.rs
@@ -26,14 +26,19 @@
 
 #[doc(inline)]
 pub use sophia_api as api;
+#[doc(inline)]
 pub use sophia_c14n as c14n;
 #[doc(inline)]
 pub use sophia_inmem as inmem;
+#[doc(inline)]
 pub use sophia_iri as iri;
+#[doc(inline)]
 pub use sophia_isomorphism as isomorphism;
 #[cfg(feature = "jsonld")]
 pub use sophia_jsonld as jsonld;
+#[doc(inline)]
 pub use sophia_resource as resource;
+#[doc(inline)]
 pub use sophia_term as term;
 pub use sophia_turtle as turtle;
 #[cfg(feature = "xml")]

--- a/sophia/src/lib.rs
+++ b/sophia/src/lib.rs
@@ -24,6 +24,7 @@
 //! [Linked Data]: http://linkeddata.org/
 #![deny(missing_docs)]
 
+#[doc(inline)]
 pub use sophia_api as api;
 pub use sophia_c14n as c14n;
 pub use sophia_inmem as inmem;

--- a/sophia/src/lib.rs
+++ b/sophia/src/lib.rs
@@ -27,6 +27,7 @@
 #[doc(inline)]
 pub use sophia_api as api;
 pub use sophia_c14n as c14n;
+#[doc(inline)]
 pub use sophia_inmem as inmem;
 pub use sophia_iri as iri;
 pub use sophia_isomorphism as isomorphism;


### PR DESCRIPTION
Current https://docs.rs/sophia/latest/sophia/ does not reexport documentation for workspace crates making documentation navigation a bit cumbersome. This PR calls `#[doc(inline)]` to re-export documentation:
https://github.com/pchampin/sophia_rs/blob/a5cca57cfad8aab51a31b24468068389b1d6616b/sophia/src/lib.rs#L27-L45