### PR TITLE
handle `xsd::decimal` in `TryFromTerm for f64`

### DIFF
--- a/api/src/term/_native_literal.rs
+++ b/api/src/term/_native_literal.rs
@@ -235,6 +235,7 @@ impl TryFromTerm for f64 {
         if let Some(lex) = term.lexical_form() {
             if Term::eq(&term.datatype().unwrap(), xsd::double)
                 || Term::eq(&term.datatype().unwrap(), xsd::float)
+                || Term::eq(&term.datatype().unwrap(), xsd::decimal)
             {
                 lex.parse()
             } else {


### PR DESCRIPTION
Doing a `TryFromTerm` on a list of `xsd::decimals` would previously produce a `wrong datatype` error since the list below example would produce literals with the `decimal` type (`^^"http://www.w3.org/2001/XMLSchema#decimal"`):
```ttl
:a _:list (2.00 4.00)
```