### PR TITLE
Introduce `Not` for `GraphNameMatcher` and `TermMatcher`

### DIFF
--- a/api/src/term/matcher.rs
+++ b/api/src/term/matcher.rs
@@ -21,14 +21,16 @@ mod _datatype_matcher;
 mod _graph_name_matcher;
 mod _language_tag_matcher;
 mod _matcher_ref;
+mod _not;
 mod _term_matcher_gn;
 mod _trait;
 
-pub use _any::*;
+pub use _any::Any;
 pub use _datatype_matcher::*;
 pub use _graph_name_matcher::*;
 pub use _language_tag_matcher::*;
 pub use _matcher_ref::*;
+pub use _not::Not;
 pub use _term_matcher_gn::*;
 pub use _trait::*;
 

--- a/api/src/term/matcher.rs
+++ b/api/src/term/matcher.rs
@@ -66,10 +66,12 @@ mod test {
         is_graph_name_matcher([Some(T1), Some(T2), None]);
         is_graph_name_matcher(&[Some(T1), Some(T2), None][..]);
         is_graph_name_matcher(|t: Option<SimpleTerm>| t.is_some());
+        is_graph_name_matcher(Not(|t: Option<SimpleTerm>| t.is_some()));
         is_graph_name_matcher([T1, T2].gn());
         is_graph_name_matcher(Some(TermKind::Iri));
         is_graph_name_matcher(Some(([T1], [T2], [T3])));
         is_graph_name_matcher([Some(T1)].matcher_ref());
+        is_graph_name_matcher(Not([Some(T1)].matcher_ref()));
     }
 
     #[test]
@@ -175,6 +177,12 @@ mod test {
         assert!(TermMatcher::matches(&Any, &T2));
         assert!(TermMatcher::matches(&Any, &T3));
         assert!(TermMatcher::constant(&Any).is_none());
+    }
+
+    #[test]
+    fn not() {
+        assert!(Not(TermKind::BlankNode).matches(&T1));
+        assert!(Not([T1, T2]).matches(&T3));
     }
 
     #[test]
@@ -330,6 +338,13 @@ mod test {
         assert!(GraphNameMatcher::matches(&Any, Some(&T2)));
         assert!(GraphNameMatcher::matches(&Any, Some(&T3)));
         assert!(GraphNameMatcher::constant(&Any).is_none());
+    }
+
+    #[test]
+    fn graph_name_not() {
+        assert!(GraphNameMatcher::matches(&Not([DEFAULT]), Some(&T1)));
+        assert!(!GraphNameMatcher::matches(&Not([T1, T2].gn()), Some(&T2)));
+        assert!(GraphNameMatcher::matches(&Not([T1, T2].gn()), Some(&T3)));
     }
 
     #[test]

--- a/api/src/term/matcher/_any.rs
+++ b/api/src/term/matcher/_any.rs
@@ -11,3 +11,14 @@ impl TermMatcher for Any {
         true
     }
 }
+
+/// Matches on the inverse of the inner [`Term`] or [`GraphName`]
+pub struct Not<M>(pub M);
+
+impl<M: TermMatcher> TermMatcher for Not<M> {
+    type Term = SimpleTerm<'static>; // not actually used
+
+    fn matches<T2: Term + ?Sized>(&self, term: &T2) -> bool {
+        !self.0.matches(term)
+    }
+}

--- a/api/src/term/matcher/_any.rs
+++ b/api/src/term/matcher/_any.rs
@@ -11,14 +11,3 @@ impl TermMatcher for Any {
         true
     }
 }
-
-/// Matches on the inverse of the inner [`Term`] or [`GraphName`]
-pub struct Not<M>(pub M);
-
-impl<M: TermMatcher> TermMatcher for Not<M> {
-    type Term = SimpleTerm<'static>; // not actually used
-
-    fn matches<T2: Term + ?Sized>(&self, term: &T2) -> bool {
-        !self.0.matches(term)
-    }
-}

--- a/api/src/term/matcher/_graph_name_matcher.rs
+++ b/api/src/term/matcher/_graph_name_matcher.rs
@@ -136,9 +136,6 @@ impl GraphNameMatcher for Any {
     }
 }
 
-/// Matches on the inverse of the inner [`GraphNameMatcher`]
-pub struct Not<M>(pub M);
-
 impl<M: GraphNameMatcher> GraphNameMatcher for Not<M> {
     type Term = SimpleTerm<'static>; // not actually used
 
@@ -148,7 +145,7 @@ impl<M: GraphNameMatcher> GraphNameMatcher for Not<M> {
 }
 
 impl GraphNameMatcher for Option<SimpleTerm<'static>> {
-    type Term = SimpleTerm<'static>; // not actually used
+    type Term = SimpleTerm<'static>;
 
     fn matches<T2: Term + ?Sized>(&self, graph_name: GraphName<&T2>) -> bool {
         graph_name_eq(self.as_ref(), graph_name.map(Term::as_simple))

--- a/api/src/term/matcher/_graph_name_matcher.rs
+++ b/api/src/term/matcher/_graph_name_matcher.rs
@@ -135,3 +135,22 @@ impl GraphNameMatcher for Any {
         true
     }
 }
+
+/// Matches on the inverse of the inner [`GraphNameMatcher`]
+pub struct Not<M>(pub M);
+
+impl<M: GraphNameMatcher> GraphNameMatcher for Not<M> {
+    type Term = SimpleTerm<'static>; // not actually used
+
+    fn matches<T2: Term + ?Sized>(&self, graph_name: GraphName<&T2>) -> bool {
+        !self.0.matches(graph_name)
+    }
+}
+
+impl GraphNameMatcher for Option<SimpleTerm<'static>> {
+    type Term = SimpleTerm<'static>; // not actually used
+
+    fn matches<T2: Term + ?Sized>(&self, graph_name: GraphName<&T2>) -> bool {
+        graph_name_eq(self.as_ref(), graph_name.map(Term::as_simple))
+    }
+}

--- a/api/src/term/matcher/_graph_name_matcher.rs
+++ b/api/src/term/matcher/_graph_name_matcher.rs
@@ -143,11 +143,3 @@ impl<M: GraphNameMatcher> GraphNameMatcher for Not<M> {
         !self.0.matches(graph_name)
     }
 }
-
-impl GraphNameMatcher for Option<SimpleTerm<'static>> {
-    type Term = SimpleTerm<'static>;
-
-    fn matches<T2: Term + ?Sized>(&self, graph_name: GraphName<&T2>) -> bool {
-        graph_name_eq(self.as_ref(), graph_name.map(Term::as_simple))
-    }
-}

--- a/api/src/term/matcher/_not.rs
+++ b/api/src/term/matcher/_not.rs
@@ -1,0 +1,12 @@
+use super::*;
+
+/// Matches on the inverse of the inner [`Term`] or [`GraphName`]
+pub struct Not<M>(pub M);
+
+impl<M: TermMatcher> TermMatcher for Not<M> {
+    type Term = SimpleTerm<'static>; // not actually used
+
+    fn matches<T2: Term + ?Sized>(&self, term: &T2) -> bool {
+        !self.0.matches(term)
+    }
+}


### PR DESCRIPTION
It was often found handy to exclude certain terms or graph names during a filter:
```rust
let my_graph_name: SimpleTerm<'static> =
    default_namespace.get_unchecked("#my_graph").into_term();
let ds_without_my_graph: Vec<Spog<SimpleTerm>> = dataset
    .quads_matching(Any, Any, Any, Not(Some(my_graph_name)))
    .collect_quads()
    .unwrap();
```