### PR TITLE
chore: apply non-default clippy fixes

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,0 +1,1 @@
+allowed-wildcard-imports = [ "super" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,3 +58,7 @@ url = "2.4.1"
 
 [profile.release]
 lto = true
+
+[workspace.lints.clippy]
+enum_glob_use = "allow"
+

--- a/c14n/src/_c14n_term.rs
+++ b/c14n/src/_c14n_term.rs
@@ -8,7 +8,7 @@ pub enum C14nTerm<T: Term> {
     Blank(BnodeId<Rc<str>>),
     Other(T),
 }
-use C14nTerm::*;
+use C14nTerm::{Blank, Other};
 
 impl<T: Term> Term for C14nTerm<T> {
     type BorrowTerm<'x> = &'x Self where Self: 'x;

--- a/c14n/src/hash.rs
+++ b/c14n/src/hash.rs
@@ -23,7 +23,7 @@ impl HashFunction for Sha256 {
     type Output = [u8; 32];
 
     fn initialize() -> Self {
-        Sha256(sha2::Sha256::new())
+        Self(sha2::Sha256::new())
     }
 
     fn update(&mut self, data: impl AsRef<[u8]>) {
@@ -42,7 +42,7 @@ impl HashFunction for Sha384 {
     type Output = [u8; 48];
 
     fn initialize() -> Self {
-        Sha384(sha2::Sha384::new())
+        Self(sha2::Sha384::new())
     }
 
     fn update(&mut self, data: impl AsRef<[u8]>) {

--- a/c14n/src/lib.rs
+++ b/c14n/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! TODO list:
 //! - [x] check that UTF-8 byte-by-byte ordering is indeed equivalent to code point ordering.
-//! - [ ] use c14n in sophia_isomorphism, replacing the current incomplete algorithm
+//! - [ ] use c14n in `sophia_isomorphism`, replacing the current incomplete algorithm
 //!
 //! [Sophia]: https://docs.rs/sophia/latest/sophia/
 //! [RDF]: https://www.w3.org/TR/rdf-primer/

--- a/iri/benches/bench1.rs
+++ b/iri/benches/bench1.rs
@@ -1,12 +1,12 @@
 //! This benchmark is used to compare the time it takes to create
-//! * borrowing MownStr's vs. standard &str references
-//! * owning MownStr's vs. Strings
+//! * borrowing `MownStr`'s vs. standard &str references
+//! * owning `MownStr`'s vs. Strings
 //!
 //! The results of `borrowed_mownstr` should therefore be compared to `refs`,
 //! and that of `owned_mownstr` should be compared to `strings`.
 
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
-use sophia_iri::resolve::*;
+use sophia_iri::resolve::{BaseIri, BaseIriRef};
 
 fn parse(c: &mut Criterion) {
     c.bench_with_input(
@@ -25,7 +25,7 @@ fn parse(c: &mut Criterion) {
                         black_box(BaseIriRef::new(*iri).is_ok());
                     }
                 }
-            })
+            });
         },
     );
 }
@@ -42,7 +42,7 @@ fn resolve_from_scratch(c: &mut Criterion) {
                         black_box(&base.resolve(*rel).unwrap());
                     }
                 }
-            })
+            });
         },
     );
 }
@@ -58,7 +58,7 @@ fn resolve_mutualized(c: &mut Criterion) {
                         black_box(i.0.resolve(*rel).unwrap());
                     }
                 }
-            })
+            });
         },
     );
 }

--- a/iri/src/_regex.rs
+++ b/iri/src/_regex.rs
@@ -8,7 +8,7 @@ use regex::Regex;
 /// is not `None`.
 /// Future implementations may be smarter about this.
 #[inline]
-pub fn is_valid_suffixed_iri_ref(ns: &str, suffix: Option<&str>) -> bool {
+#[must_use] pub fn is_valid_suffixed_iri_ref(ns: &str, suffix: Option<&str>) -> bool {
     match suffix {
         None => is_valid_iri_ref(ns),
         Some(suffix) => {
@@ -22,19 +22,19 @@ pub fn is_valid_suffixed_iri_ref(ns: &str, suffix: Option<&str>) -> bool {
 
 /// Check whether `txt` is a valid (absolute or relative) IRI reference.
 #[inline]
-pub fn is_valid_iri_ref(txt: &str) -> bool {
+#[must_use] pub fn is_valid_iri_ref(txt: &str) -> bool {
     IRI_REGEX.is_match(txt) || IRELATIVE_REF_REGEX.is_match(txt)
 }
 
 /// Check whether `txt` is an absolute IRI reference.
 #[inline]
-pub fn is_absolute_iri_ref(txt: &str) -> bool {
+#[must_use] pub fn is_absolute_iri_ref(txt: &str) -> bool {
     IRI_REGEX.is_match(txt)
 }
 
 /// Check whether `txt` is a relative IRI reference.
 #[inline]
-pub fn is_relative_iri_ref(txt: &str) -> bool {
+#[must_use] pub fn is_relative_iri_ref(txt: &str) -> bool {
     IRELATIVE_REF_REGEX.is_match(txt)
 }
 

--- a/iri/src/_regex.rs
+++ b/iri/src/_regex.rs
@@ -8,7 +8,8 @@ use regex::Regex;
 /// is not `None`.
 /// Future implementations may be smarter about this.
 #[inline]
-#[must_use] pub fn is_valid_suffixed_iri_ref(ns: &str, suffix: Option<&str>) -> bool {
+#[must_use]
+pub fn is_valid_suffixed_iri_ref(ns: &str, suffix: Option<&str>) -> bool {
     match suffix {
         None => is_valid_iri_ref(ns),
         Some(suffix) => {
@@ -22,19 +23,22 @@ use regex::Regex;
 
 /// Check whether `txt` is a valid (absolute or relative) IRI reference.
 #[inline]
-#[must_use] pub fn is_valid_iri_ref(txt: &str) -> bool {
+#[must_use]
+pub fn is_valid_iri_ref(txt: &str) -> bool {
     IRI_REGEX.is_match(txt) || IRELATIVE_REF_REGEX.is_match(txt)
 }
 
 /// Check whether `txt` is an absolute IRI reference.
 #[inline]
-#[must_use] pub fn is_absolute_iri_ref(txt: &str) -> bool {
+#[must_use]
+pub fn is_absolute_iri_ref(txt: &str) -> bool {
     IRI_REGEX.is_match(txt)
 }
 
 /// Check whether `txt` is a relative IRI reference.
 #[inline]
-#[must_use] pub fn is_relative_iri_ref(txt: &str) -> bool {
+#[must_use]
+pub fn is_relative_iri_ref(txt: &str) -> bool {
     IRELATIVE_REF_REGEX.is_match(txt)
 }
 

--- a/iri/src/_serde.rs
+++ b/iri/src/_serde.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::{Iri, IriRef, Result};
 use serde::{
     de::{Error, Unexpected},
     Deserialize, Serialize,
@@ -11,7 +11,7 @@ impl<'a, T: Borrow<str> + Deserialize<'a>> Deserialize<'a> for Iri<T> {
         D: serde::Deserializer<'a>,
     {
         let inner: T = T::deserialize(deserializer)?;
-        Iri::new(inner)
+        Self::new(inner)
             .map_err(|err| D::Error::invalid_value(Unexpected::Str(&err.0), &"valid IRI"))
     }
 }
@@ -31,7 +31,7 @@ impl<'a, T: Borrow<str> + Deserialize<'a>> Deserialize<'a> for IriRef<T> {
         D: serde::Deserializer<'a>,
     {
         let inner: T = T::deserialize(deserializer)?;
-        IriRef::new(inner)
+        Self::new(inner)
             .map_err(|err| D::Error::invalid_value(Unexpected::Str(&err.0), &"valid IRI reference"))
     }
 }

--- a/iri/src/_wrap_macro.rs
+++ b/iri/src/_wrap_macro.rs
@@ -243,7 +243,7 @@ macro_rules! wrap {
                 "If it is not, it may result in undefined behaviour.",
             )]
             #[allow(dead_code)]
-            pub const fn new_unchecked_const(inner: &'static $bid) -> Self {
+            #[must_use] pub const fn new_unchecked_const(inner: &'static $bid) -> Self {
                 $wid(inner)
             }
         }
@@ -415,7 +415,7 @@ pub mod test_wrap_borrowing {
     // only check that this compiles
     #[allow(dead_code)]
     fn new_unchecked() {
-        let _: Foo<String> = Foo::new_unchecked("".into());
+        let _: Foo<String> = Foo::new_unchecked(String::new());
     }
 
     // only check that this compiles

--- a/iri/src/_wrapper.rs
+++ b/iri/src/_wrapper.rs
@@ -1,7 +1,7 @@
 //! I provide generic wrappers around `Borrow<str>` types,
 //! guaranteeing that their underlying string is a valid IRI or IRI reference.
 use super::resolve::{BaseIri, BaseIriRef};
-use super::{InvalidIri, IsIri, IsIriRef, *};
+use super::{InvalidIri, IsIri, IsIriRef, Result, is_absolute_iri_ref, is_valid_iri_ref, wrap};
 use std::borrow::Borrow;
 use std::fmt::Display;
 
@@ -108,46 +108,46 @@ mod test {
     #[test]
     fn iri() {
         for (txt, (abs, ..)) in POSITIVE_IRIS {
-            assert!(Iri::new(*txt).is_ok() == *abs)
+            assert!(Iri::new(*txt).is_ok() == *abs);
         }
         for txt in NEGATIVE_IRIS {
-            assert!(Iri::new(*txt).is_err())
+            assert!(Iri::new(*txt).is_err());
         }
     }
 
     #[test]
     fn iri_box() {
         for (txt, (abs, ..)) in POSITIVE_IRIS {
-            assert!(Iri::new(Box::from(txt as &str)).is_ok() == *abs)
+            assert!(Iri::new(Box::from(txt as &str)).is_ok() == *abs);
         }
         for txt in NEGATIVE_IRIS {
-            assert!(Iri::new(Box::from(txt as &str)).is_err())
+            assert!(Iri::new(Box::from(txt as &str)).is_err());
         }
     }
 
     #[test]
     fn iri_ref() {
         for (txt, _) in POSITIVE_IRIS {
-            assert!(IriRef::new(*txt).is_ok())
+            assert!(IriRef::new(*txt).is_ok());
         }
         for txt in NEGATIVE_IRIS {
-            assert!(IriRef::new(*txt).is_err())
+            assert!(IriRef::new(*txt).is_err());
         }
         for (txt, _) in RELATIVE_IRIS {
-            assert!(IriRef::new(*txt).is_ok())
+            assert!(IriRef::new(*txt).is_ok());
         }
     }
 
     #[test]
     fn iri_ref_box() {
         for (txt, _) in POSITIVE_IRIS {
-            assert!(IriRef::new(Box::from(txt as &str)).is_ok())
+            assert!(IriRef::new(Box::from(txt as &str)).is_ok());
         }
         for txt in NEGATIVE_IRIS {
-            assert!(IriRef::new(Box::from(txt as &str)).is_err())
+            assert!(IriRef::new(Box::from(txt as &str)).is_err());
         }
         for (txt, _) in RELATIVE_IRIS {
-            assert!(IriRef::new(Box::from(txt as &str)).is_ok())
+            assert!(IriRef::new(Box::from(txt as &str)).is_ok());
         }
     }
 

--- a/iri/src/_wrapper.rs
+++ b/iri/src/_wrapper.rs
@@ -1,7 +1,7 @@
 //! I provide generic wrappers around `Borrow<str>` types,
 //! guaranteeing that their underlying string is a valid IRI or IRI reference.
 use super::resolve::{BaseIri, BaseIriRef};
-use super::{InvalidIri, IsIri, IsIriRef, Result, is_absolute_iri_ref, is_valid_iri_ref, wrap};
+use super::{is_absolute_iri_ref, is_valid_iri_ref, wrap, InvalidIri, IsIri, IsIriRef, Result};
 use std::borrow::Borrow;
 use std::fmt::Display;
 

--- a/iri/src/lib.rs
+++ b/iri/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! # Feature gates
 //!
-//! - **test_data** exposes the [`test`](`mod@test`) module,
+//! - **`test_data`** exposes the [`test`](`mod@test`) module,
 //!   which contains arrays of good and bad IRIs,
 //!   useful for testing purposes, possibly in other crates.
 //!

--- a/iri/src/resolve.rs
+++ b/iri/src/resolve.rs
@@ -42,7 +42,7 @@ impl<T: Deref<Target = str>> BaseIri<T> {
         iri: R,
         buf: &'a mut String,
     ) -> R::OutputAbs {
-        R::output_abs(self.0.resolve_into(iri.borrow(), buf).map(|_| &buf[..]))
+        R::output_abs(self.0.resolve_into(iri.borrow(), buf).map(|()| &buf[..]))
     }
 }
 
@@ -88,7 +88,7 @@ impl<T: Deref<Target = str>> BaseIriRef<T> {
         iri: R,
         buf: &'a mut String,
     ) -> R::OutputRel {
-        R::output_rel(self.0.resolve_into(iri.borrow(), buf).map(|_| &buf[..]))
+        R::output_rel(self.0.resolve_into(iri.borrow(), buf).map(|()| &buf[..]))
     }
 
     /// Convert this to a [`BaseIri`].
@@ -176,7 +176,7 @@ mod test {
 
             let rbi = BaseIri::new(*txt);
             if parsed.0 {
-                assert!(rbi.is_ok(), "<{}> → {:?}", txt, rbi);
+                assert!(rbi.is_ok(), "<{txt}> → {rbi:?}");
                 let bi = rbi.unwrap();
                 assert_eq!(bi.scheme(), parsed.1.unwrap());
                 assert_eq!(bi.authority(), parsed.2);
@@ -189,7 +189,7 @@ mod test {
                 assert_eq!(bi, Iri::new(*txt).unwrap().to_base());
                 assert_eq!(bi, Iri::new(*txt).unwrap().as_base());
             } else {
-                assert!(rbi.is_err(), "<{}> → {:?}", txt, rbi);
+                assert!(rbi.is_err(), "<{txt}> → {rbi:?}");
             }
         }
     }
@@ -198,9 +198,9 @@ mod test {
     fn negative() {
         for txt in NEGATIVE_IRIS {
             let rpir = BaseIriRef::new(*txt);
-            assert!(rpir.is_err(), "<{}> → {:?}", txt, rpir);
+            assert!(rpir.is_err(), "<{txt}> → {rpir:?}");
             let rpi = BaseIri::new(*txt);
-            assert!(rpi.is_err(), "<{}> → {:?}", txt, rpi);
+            assert!(rpi.is_err(), "<{txt}> → {rpi:?}");
         }
     }
 
@@ -208,13 +208,13 @@ mod test {
     fn relative() {
         for (rel, abs) in RELATIVE_IRIS {
             let rbir = BaseIriRef::new(*rel);
-            assert!(rbir.is_ok(), "<{}> → {:?}", rel, rbir);
+            assert!(rbir.is_ok(), "<{rel}> → {rbir:?}");
 
             let rbi = BaseIri::new(*rel);
             if rel != abs {
-                assert!(rbi.is_err(), "<{}> → {:?}", rel, rbi);
+                assert!(rbi.is_err(), "<{rel}> → {rbi:?}");
             } else {
-                assert!(rbi.is_ok(), "<{}> → {:?}", rel, rbi);
+                assert!(rbi.is_ok(), "<{rel}> → {rbi:?}");
                 assert_eq!(rbir.unwrap().as_iri_ref(), rbi.unwrap().as_iri_ref());
             }
         }

--- a/isomorphism/src/dataset.rs
+++ b/isomorphism/src/dataset.rs
@@ -1,5 +1,5 @@
 use super::hash::hash_quad_with;
-use super::iso_term::{IsoTerm, cmp_quads};
+use super::iso_term::{cmp_quads, IsoTerm};
 use sophia_api::quad::{iter_spog, Quad};
 use sophia_api::{
     dataset::{DTerm, Dataset},

--- a/isomorphism/src/dataset.rs
+++ b/isomorphism/src/dataset.rs
@@ -1,5 +1,5 @@
-use super::hash::*;
-use super::iso_term::*;
+use super::hash::hash_quad_with;
+use super::iso_term::{IsoTerm, cmp_quads};
 use sophia_api::quad::{iter_spog, Quad};
 use sophia_api::{
     dataset::{DTerm, Dataset},
@@ -137,7 +137,7 @@ fn make_map<'a, T: Term>(
 
 fn make_equivalence_classes(map: &HashMap<&str, u64>) -> HashMap<u64, usize> {
     let mut ret = HashMap::new();
-    for (_, v) in map.iter() {
+    for (_, v) in map {
         let n = ret.entry(*v).or_insert(0);
         *n += 1;
     }

--- a/isomorphism/src/iso_term.rs
+++ b/isomorphism/src/iso_term.rs
@@ -67,7 +67,7 @@ impl<T: Term> Term for IsoTerm<T> {
         self.0.eq(other)
     }
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.0.hash(state)
+        self.0.hash(state);
     }
     fn into_term<U: FromTerm>(self) -> U {
         self.0.into_term()

--- a/isomorphism/src/test.rs
+++ b/isomorphism/src/test.rs
@@ -149,9 +149,7 @@ fn quoted_triple() -> Result<(), Box<dyn Error>> {
 
 fn make_chain(ids: &'static str) -> Vec<[MyTerm; 4]> {
     let rel = MyTerm::Iri("tag:rel");
-    let nodes: Vec<_> = (0..ids.len())
-        .map(|i| MyTerm::Bnode(&ids[i..=i]))
-        .collect();
+    let nodes: Vec<_> = (0..ids.len()).map(|i| MyTerm::Bnode(&ids[i..=i])).collect();
     let mut dataset = Vec::with_capacity(ids.len() - 1);
     for i in 1..nodes.len() {
         dataset.push([nodes[i - 1], rel, nodes[i], nodes[i - 1]]);
@@ -236,9 +234,7 @@ fn cycle_almost_pathological() -> Result<(), Box<dyn Error>> {
 
 fn make_clique(ids: &'static str) -> Vec<[MyTerm; 4]> {
     let rel = MyTerm::Iri("tag:rel");
-    let nodes: Vec<_> = (0..ids.len())
-        .map(|i| MyTerm::Bnode(&ids[i..=i]))
-        .collect();
+    let nodes: Vec<_> = (0..ids.len()).map(|i| MyTerm::Bnode(&ids[i..=i])).collect();
     let mut dataset = Vec::with_capacity(ids.len() * ids.len());
     for n1 in &nodes {
         for n2 in &nodes {
@@ -264,9 +260,7 @@ fn clique() -> Result<(), Box<dyn Error>> {
 
 fn make_tree(ids: &'static str) -> Vec<[MyTerm; 4]> {
     let rel = MyTerm::Iri("tag:rel");
-    let nodes: Vec<_> = (0..ids.len())
-        .map(|i| MyTerm::Bnode(&ids[i..=i]))
-        .collect();
+    let nodes: Vec<_> = (0..ids.len()).map(|i| MyTerm::Bnode(&ids[i..=i])).collect();
     let mut dataset = Vec::with_capacity(ids.len() * ids.len());
     let mut i = 0;
     while 2 * i < nodes.len() {

--- a/jsonld/src/context.rs
+++ b/jsonld/src/context.rs
@@ -48,8 +48,8 @@ impl TryIntoContextRef for &str {
     fn try_into_context_ref(self) -> Result<ContextRef, Self::Error> {
         let iri = ArcIri::new_unchecked("x-string://".into());
         let doc = Value::parse_str(self, |span| locspan::Location::new(iri.clone(), span))?;
-        let context = Value::extract_context(doc)
-            .map_err(|e| format!("Could not extract @context: {e}"))?;
+        let context =
+            Value::extract_context(doc).map_err(|e| format!("Could not extract @context: {e}"))?;
         let rdoc = RemoteDocument::new(None, None, context);
         Ok(RemoteDocumentReference::Loaded(rdoc))
     }

--- a/jsonld/src/context.rs
+++ b/jsonld/src/context.rs
@@ -49,7 +49,7 @@ impl TryIntoContextRef for &str {
         let iri = ArcIri::new_unchecked("x-string://".into());
         let doc = Value::parse_str(self, |span| locspan::Location::new(iri.clone(), span))?;
         let context = Value::extract_context(doc)
-            .map_err(|e| format!("Could not extract @context: {}", e))?;
+            .map_err(|e| format!("Could not extract @context: {e}"))?;
         let rdoc = RemoteDocument::new(None, None, context);
         Ok(RemoteDocumentReference::Loaded(rdoc))
     }

--- a/jsonld/src/error.rs
+++ b/jsonld/src/error.rs
@@ -40,13 +40,13 @@ pub enum JsonLdError {
 
     /// Poisonned lock
     ///
-    /// NB: PoisonError is generic, so we keep the message only
+    /// NB: `PoisonError` is generic, so we keep the message only
     #[error("poisonned lock for document loader: {0}")]
     PoisonnedLock(String),
 
     /// An expansion error was encountered while parsing
     ///
-    /// NB: ExpandError is generic, so we keep the message only
+    /// NB: `ExpandError` is generic, so we keep the message only
     #[error("error while expanding: {0}")]
     ExpandError(String),
 
@@ -58,20 +58,20 @@ pub enum JsonLdError {
 impl From<Meta<Error<Location<ArcIri, Span>>, Location<ArcIri, Span>>> for JsonLdError {
     fn from(other: Meta<Error<Location<ArcIri, Span>>, Location<ArcIri, Span>>) -> Self {
         let Meta(error, location) = other;
-        JsonLdError::InvalidJson { error, location }
+        Self::InvalidJson { error, location }
     }
 }
 
 impl From<Meta<Error<Span>, Span>> for JsonLdError {
     fn from(other: Meta<Error<Span>, Span>) -> Self {
         let Meta(error, location) = other;
-        JsonLdError::InvalidJsonLiteral { error, location }
+        Self::InvalidJsonLiteral { error, location }
     }
 }
 
 impl<T> From<PoisonError<T>> for JsonLdError {
     fn from(value: PoisonError<T>) -> Self {
-        JsonLdError::PoisonnedLock(format!("{value}"))
+        Self::PoisonnedLock(format!("{value}"))
     }
 }
 
@@ -80,6 +80,6 @@ where
     ExpandError<M, E, C>: Display,
 {
     fn from(value: ExpandError<M, E, C>) -> Self {
-        JsonLdError::ExpandError(format!("{value}"))
+        Self::ExpandError(format!("{value}"))
     }
 }

--- a/jsonld/src/loader/chain_loader.rs
+++ b/jsonld/src/loader/chain_loader.rs
@@ -11,8 +11,8 @@ pub struct ChainLoader<L1, L2>(L1, L2);
 
 impl<L1, L2> ChainLoader<L1, L2> {
     /// Build a new chain loader
-    pub fn new(l1: L1, l2: L2) -> Self {
-        ChainLoader(l1, l2)
+    pub const fn new(l1: L1, l2: L2) -> Self {
+        Self(l1, l2)
     }
 }
 

--- a/jsonld/src/loader/closure_loader.rs
+++ b/jsonld/src/loader/closure_loader.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::{Arc, Iri, Value};
 use json_ld::future::{BoxFuture, FutureExt};
 use json_ld::{Loader, RemoteDocument};
 use json_syntax::Parse;
@@ -59,7 +59,7 @@ where
     F: Send + FnMut(Iri<String>) -> BoxFuture<'f, Result<String, String>>,
 {
     /// Creates a new closure loader with the given closure.
-    pub fn new(f: F) -> Self {
+    pub const fn new(f: F) -> Self {
         Self { closure: f }
     }
 }

--- a/jsonld/src/loader/file_url_loader.rs
+++ b/jsonld/src/loader/file_url_loader.rs
@@ -68,7 +68,8 @@ impl Loader<Iri<Arc<str>>, Location<Iri<Arc<str>>>> for FileUrlLoader {
 
 impl FileUrlLoader {
     /// Creates a new file system loader with the given content `parser`.
-    #[must_use] pub fn new() -> Self {
+    #[must_use]
+    pub fn new() -> Self {
         Self::default()
     }
 }

--- a/jsonld/src/loader/file_url_loader.rs
+++ b/jsonld/src/loader/file_url_loader.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::{Arc, Iri, Value};
 use json_ld::future::{BoxFuture, FutureExt};
 use json_ld::{Loader, RemoteDocument};
 use json_syntax::Parse;
@@ -45,7 +45,7 @@ impl Loader<Iri<Arc<str>>, Location<Iri<Arc<str>>>> for FileUrlLoader {
             let url_parsed = Url::parse(url_str).map_err(Self::Error::InvalidUrl)?;
             let path = url_parsed
                 .to_file_path()
-                .map_err(|_| Self::Error::BadFileUrl(url_str.into()))?;
+                .map_err(|()| Self::Error::BadFileUrl(url_str.into()))?;
             let file = File::open(path).map_err(Self::Error::IO)?;
             let mut buf_reader = BufReader::new(file);
             let mut contents = String::new();
@@ -68,7 +68,7 @@ impl Loader<Iri<Arc<str>>, Location<Iri<Arc<str>>>> for FileUrlLoader {
 
 impl FileUrlLoader {
     /// Creates a new file system loader with the given content `parser`.
-    pub fn new() -> Self {
+    #[must_use] pub fn new() -> Self {
         Self::default()
     }
 }

--- a/jsonld/src/loader/static_loader.rs
+++ b/jsonld/src/loader/static_loader.rs
@@ -33,7 +33,7 @@ impl<I, S> Default for StaticLoader<I, S> {
 
 impl<I: IsIri, S> StaticLoader<I, S> {
     /// Creates a new [`StaticLoader`]
-    pub fn new() -> Self {
+    #[must_use] pub fn new() -> Self {
         Self::default()
     }
 

--- a/jsonld/src/loader/static_loader.rs
+++ b/jsonld/src/loader/static_loader.rs
@@ -33,7 +33,8 @@ impl<I, S> Default for StaticLoader<I, S> {
 
 impl<I: IsIri, S> StaticLoader<I, S> {
     /// Creates a new [`StaticLoader`]
-    #[must_use] pub fn new() -> Self {
+    #[must_use]
+    pub fn new() -> Self {
         Self::default()
     }
 

--- a/jsonld/src/loader_factory.rs
+++ b/jsonld/src/loader_factory.rs
@@ -45,7 +45,8 @@ where
 {
     /// Create a new [`DefaultLoaderFactory`].
     #[inline]
-    #[must_use] pub fn new() -> Self {
+    #[must_use]
+    pub fn new() -> Self {
         Self::default()
     }
 }

--- a/jsonld/src/loader_factory.rs
+++ b/jsonld/src/loader_factory.rs
@@ -45,7 +45,7 @@ where
 {
     /// Create a new [`DefaultLoaderFactory`].
     #[inline]
-    pub fn new() -> Self {
+    #[must_use] pub fn new() -> Self {
         Self::default()
     }
 }

--- a/jsonld/src/options.rs
+++ b/jsonld/src/options.rs
@@ -43,7 +43,8 @@ pub struct JsonLdOptions<LF> {
 
 impl JsonLdOptions<DefaultLoaderFactory<NoLoader>> {
     /// Build a new JSON-LD options.
-    #[must_use] pub fn new() -> Self {
+    #[must_use]
+    pub fn new() -> Self {
         Self::default()
     }
 }

--- a/jsonld/src/options.rs
+++ b/jsonld/src/options.rs
@@ -14,7 +14,7 @@ use locspan::Location;
 use locspan::Span;
 use sophia_iri::Iri;
 
-use crate::context::*;
+use crate::context::{ContextRef, IntoContextRef, TryIntoContextRef};
 use crate::loader::NoLoader;
 use crate::loader_factory::ClosureLoaderFactory;
 use crate::loader_factory::DefaultLoaderFactory;
@@ -43,7 +43,7 @@ pub struct JsonLdOptions<LF> {
 
 impl JsonLdOptions<DefaultLoaderFactory<NoLoader>> {
     /// Build a new JSON-LD options.
-    pub fn new() -> Self {
+    #[must_use] pub fn new() -> Self {
         Self::default()
     }
 }
@@ -60,7 +60,7 @@ impl<LF> JsonLdOptions<LF> {
     ///
     /// [`compactArrays`]: https://www.w3.org/TR/json-ld11-api/#dom-jsonldoptions-compactarrays
     /// [compaction]: https://www.w3.org/TR/json-ld11-api/#dfn-compact
-    pub fn compact_arrays(&self) -> bool {
+    pub const fn compact_arrays(&self) -> bool {
         self.inner.compact_arrays
     }
 
@@ -68,7 +68,7 @@ impl<LF> JsonLdOptions<LF> {
     ///
     /// [`compactToRelative`]: https://www.w3.org/TR/json-ld11-api/#dom-jsonldoptions-compacttorelative
     /// [compacting]: https://www.w3.org/TR/json-ld11-api/#dfn-compact
-    pub fn compact_to_relative(&self) -> bool {
+    pub const fn compact_to_relative(&self) -> bool {
         self.inner.compact_to_relative
     }
 
@@ -76,14 +76,14 @@ impl<LF> JsonLdOptions<LF> {
     /// The returned factory can yield a [`documentLoader`].
     ///
     /// [`documentLoader`]: https://www.w3.org/TR/json-ld11-api/#dom-jsonldoptions-documentloader
-    pub fn document_loader_factory(&self) -> &LF {
+    pub const fn document_loader_factory(&self) -> &LF {
         &self.loader_factory
     }
 
     /// [`expandContext`] is a context that is used to initialize the active context when expanding a document.
     ///
     /// [`expandContext`]: https://www.w3.org/TR/json-ld11-api/#dom-jsonldoptions-expandcontext
-    pub fn expand_context(&self) -> Option<&ContextRef> {
+    pub const fn expand_context(&self) -> Option<&ContextRef> {
         self.inner.expand_context.as_ref()
     }
 
@@ -92,7 +92,7 @@ impl<LF> JsonLdOptions<LF> {
     /// If false, order is not considered in processing.
     ///
     /// [`ordered`]: https://www.w3.org/TR/json-ld11-api/#dom-jsonldoptions-ordered
-    pub fn ordered(&self) -> bool {
+    pub const fn ordered(&self) -> bool {
         self.inner.ordered
     }
 
@@ -106,14 +106,14 @@ impl<LF> JsonLdOptions<LF> {
     /// [`JsonLd1_1`]: ProcessingMode::JsonLd1_1
     /// [JSON-LD 1.0]: https://json-ld.org/spec/FCGS/json-ld-syntax/20130222/
     /// [JSON-LD 1.1]: https://www.w3.org/TR/json-ld11/
-    pub fn processing_mode(&self) -> ProcessingMode {
+    pub const fn processing_mode(&self) -> ProcessingMode {
         self.inner.processing_mode
     }
 
     /// [`produceGeneralizedRdf`] authorizes the JSON-LD to emit blank nodes for triple predicates, otherwise they will be omitted.
     ///
     /// [`produceGeneralizedRdf`]: https://www.w3.org/TR/json-ld11-api/#dom-jsonldoptions-producegeneralizedrdf
-    pub fn produce_generalized_rdf(&self) -> bool {
+    pub const fn produce_generalized_rdf(&self) -> bool {
         self.inner.produce_generalized_rdf
     }
 
@@ -121,7 +121,7 @@ impl<LF> JsonLdOptions<LF> {
     /// a base direction are transformed to and from RDF.
     ///
     /// [`rdfDirection`]: https://www.w3.org/TR/json-ld11-api/#dom-jsonldoptions-rdfdirection
-    pub fn rdf_direction(&self) -> Option<RdfDirection> {
+    pub const fn rdf_direction(&self) -> Option<RdfDirection> {
         self.inner.rdf_direction
     }
 
@@ -129,7 +129,7 @@ impl<LF> JsonLdOptions<LF> {
     /// to use native JSON values in value objects avoiding the need for an explicit `@type`.
     ///
     /// [`useNativeTypes`]: https://www.w3.org/TR/json-ld11-api/#dom-jsonldoptions-usenativetypes
-    pub fn use_native_types(&self) -> bool {
+    pub const fn use_native_types(&self) -> bool {
         self.use_native_types
     }
 
@@ -138,7 +138,7 @@ impl<LF> JsonLdOptions<LF> {
     /// `@type`.
     ///
     /// [`useRdfType`]: https://www.w3.org/TR/json-ld11-api/#dom-jsonldoptions-userdftype
-    pub fn use_rdf_type(&self) -> bool {
+    pub const fn use_rdf_type(&self) -> bool {
         self.use_rdf_type
     }
 
@@ -146,25 +146,25 @@ impl<LF> JsonLdOptions<LF> {
     ///
     /// NB: this is not a standard option of JSON-LD,
     /// but a specific option of the [`json_ld` crate](json_ld).
-    pub fn expansion_policy(&self) -> Policy {
+    pub const fn expansion_policy(&self) -> Policy {
         self.inner.expansion_policy
     }
 
     /// Return the number of spaces to use for indentation in the JSON output.
     ///
     /// NB: this is not a standard option of JSON-LD.
-    pub fn spaces(&self) -> u16 {
+    pub const fn spaces(&self) -> u16 {
         self.spaces
     }
 
     /// The context to be used to compact the output, if ant.
     ///
     /// NB: this is not a standard option of JSON-LD.
-    pub fn compact_context(&self) -> Option<&ContextRef> {
+    pub const fn compact_context(&self) -> Option<&ContextRef> {
         self.compact_context.as_ref()
     }
 
-    pub(crate) fn inner(&self) -> &InnerOptions {
+    pub(crate) const fn inner(&self) -> &InnerOptions {
         &self.inner
     }
 
@@ -187,13 +187,13 @@ impl<LF> JsonLdOptions<LF> {
     }
 
     /// Change the [`compact_arrays`](Self::compact_arrays) flag
-    pub fn with_compact_arrays(mut self, compact_arrays: bool) -> Self {
+    pub const fn with_compact_arrays(mut self, compact_arrays: bool) -> Self {
         self.inner.compact_arrays = compact_arrays;
         self
     }
 
     /// Change the [`compact_to_relative`](Self::compact_to_relative) flag
-    pub fn with_compact_to_relative(mut self, compact_to_relative: bool) -> Self {
+    pub const fn with_compact_to_relative(mut self, compact_to_relative: bool) -> Self {
         self.inner.compact_to_relative = compact_to_relative;
         self
     }
@@ -328,19 +328,19 @@ impl<LF> JsonLdOptions<LF> {
     }
 
     /// Change the [`ordered`](Self::ordered) flag
-    pub fn with_ordered(mut self, ordered: bool) -> Self {
+    pub const fn with_ordered(mut self, ordered: bool) -> Self {
         self.inner.ordered = ordered;
         self
     }
 
     /// Change the [`processing_mode`](Self::processing_mode)
-    pub fn with_processing_mode(mut self, version: ProcessingMode) -> Self {
+    pub const fn with_processing_mode(mut self, version: ProcessingMode) -> Self {
         self.inner.processing_mode = version;
         self
     }
 
     /// Change the [`produce_generalized_rdf`](Self::produce_generalized_rdf) flag
-    pub fn with_produce_generalized_rdf(mut self, produce_generalized_rdf: bool) -> Self {
+    pub const fn with_produce_generalized_rdf(mut self, produce_generalized_rdf: bool) -> Self {
         self.inner.produce_generalized_rdf = produce_generalized_rdf;
         self
     }
@@ -348,7 +348,7 @@ impl<LF> JsonLdOptions<LF> {
     /// Change the [`rdf_direction`](Self::rdf_direction)
     ///
     /// See also [`with_no_rdf_direction`](Self::with_no_rdf_direction).
-    pub fn with_rdf_direction(mut self, rdf_direction: RdfDirection) -> Self {
+    pub const fn with_rdf_direction(mut self, rdf_direction: RdfDirection) -> Self {
         self.inner.rdf_direction = Some(rdf_direction);
         self
     }
@@ -356,31 +356,31 @@ impl<LF> JsonLdOptions<LF> {
     /// Change the [`rdf_direction`](Self::rdf_direction)
     ///
     /// See also [`with_rdf_direction`](Self::with_rdf_direction).
-    pub fn with_no_rdf_direction(mut self) -> Self {
+    pub const fn with_no_rdf_direction(mut self) -> Self {
         self.inner.rdf_direction = None;
         self
     }
 
     /// Change the [`use_native_types`](Self::use_native_types) flag
-    pub fn with_use_native_types(mut self, flag: bool) -> Self {
+    pub const fn with_use_native_types(mut self, flag: bool) -> Self {
         self.use_native_types = flag;
         self
     }
 
     /// Change the [`use_native_types`](Self::use_native_types) flag
-    pub fn with_use_rdf_type(mut self, flag: bool) -> Self {
+    pub const fn with_use_rdf_type(mut self, flag: bool) -> Self {
         self.use_rdf_type = flag;
         self
     }
 
     /// Change the [expansion policy](Self::expansion_policy)
-    pub fn with_expansion_policy(mut self, policy: Policy) -> Self {
+    pub const fn with_expansion_policy(mut self, policy: Policy) -> Self {
         self.inner.expansion_policy = policy;
         self
     }
 
     /// Changes the [`spaces`](Self::spaces) option
-    pub fn with_spaces(mut self, spaces: u16) -> Self {
+    pub const fn with_spaces(mut self, spaces: u16) -> Self {
         self.spaces = spaces;
         self
     }

--- a/jsonld/src/parser.rs
+++ b/jsonld/src/parser.rs
@@ -51,7 +51,8 @@ impl Default for JsonLdParser<DefaultLoaderFactory<NoLoader>> {
 
 impl JsonLdParser<DefaultLoaderFactory<NoLoader>> {
     /// Make a new [`JsonLdParser`] with the default options
-    #[must_use] pub fn new() -> Self {
+    #[must_use]
+    pub fn new() -> Self {
         Self {
             options: JsonLdOptions::default(),
         }

--- a/jsonld/src/parser.rs
+++ b/jsonld/src/parser.rs
@@ -51,8 +51,8 @@ impl Default for JsonLdParser<DefaultLoaderFactory<NoLoader>> {
 
 impl JsonLdParser<DefaultLoaderFactory<NoLoader>> {
     /// Make a new [`JsonLdParser`] with the default options
-    pub fn new() -> Self {
-        JsonLdParser {
+    #[must_use] pub fn new() -> Self {
+        Self {
             options: JsonLdOptions::default(),
         }
     }
@@ -60,12 +60,12 @@ impl JsonLdParser<DefaultLoaderFactory<NoLoader>> {
 
 impl<LF> JsonLdParser<LF> {
     /// Make a new [`JsonLdParser`] with the given options
-    pub fn new_with_options(options: JsonLdOptions<LF>) -> Self {
-        JsonLdParser { options }
+    pub const fn new_with_options(options: JsonLdOptions<LF>) -> Self {
+        Self { options }
     }
 
     /// Borrow the options of this parser
-    pub fn options(&self) -> &JsonLdOptions<LF> {
+    pub const fn options(&self) -> &JsonLdOptions<LF> {
         &self.options
     }
 

--- a/jsonld/src/parser/adapter.rs
+++ b/jsonld/src/parser/adapter.rs
@@ -71,19 +71,19 @@ impl SophiaTerm for RdfTerm {
 
 impl From<RdfO> for RdfTerm {
     fn from(value: RdfO) -> Self {
-        RdfTerm(value)
+        Self(value)
     }
 }
 
 impl From<RdfS> for RdfTerm {
     fn from(value: RdfS) -> Self {
-        RdfTerm(Term::Id(value))
+        Self(Term::Id(value))
     }
 }
 
 impl From<ArcIri> for RdfTerm {
     fn from(value: ArcIri) -> Self {
-        RdfTerm(Term::Id(Id::Iri(value)))
+        Self(Term::Id(Id::Iri(value)))
     }
 }
 

--- a/jsonld/src/parser/source.rs
+++ b/jsonld/src/parser/source.rs
@@ -22,7 +22,7 @@ pub enum JsonLdQuadSource {
 
 impl JsonLdQuadSource {
     pub(crate) fn from_err<E: Into<JsonLdError>>(err: E) -> Self {
-        JsonLdQuadSource::Err(Some(err.into()))
+        Self::Err(Some(err.into()))
     }
 }
 
@@ -37,14 +37,14 @@ impl Source for JsonLdQuadSource {
         F: FnMut(Self::Item<'_>) -> Result<(), E>,
     {
         match self {
-            JsonLdQuadSource::Quads(quads) => {
+            Self::Quads(quads) => {
                 if let Some(quad) = quads.next() {
-                    f(quad).map(|_| true).map_err(SinkError)
+                    f(quad).map(|()| true).map_err(SinkError)
                 } else {
                     Ok(false)
                 }
             }
-            JsonLdQuadSource::Err(opt) => {
+            Self::Err(opt) => {
                 if let Some(err) = opt.take() {
                     Err(SourceError(err))
                 } else {

--- a/jsonld/src/serializer.rs
+++ b/jsonld/src/serializer.rs
@@ -3,13 +3,13 @@
 //!
 //! [`Serialize RDF as JSON-LD Algorithm`]: https://www.w3.org/TR/json-ld11-api/#serialize-rdf-as-json-ld-algorithm
 
-use crate::error::*;
+use crate::error::JsonLdError;
 use crate::loader::NoLoader;
-use crate::options::*;
+use crate::options::JsonLdOptions;
 use json_syntax::print::Indent;
 use json_syntax::print::{Options, Print};
 use json_syntax::Value as JsonValue;
-use sophia_api::serializer::*;
+use sophia_api::serializer::{QuadSerializer, Stringifier};
 use sophia_api::source::{QuadSource, SinkError, StreamResult};
 
 mod engine;
@@ -38,12 +38,12 @@ impl<W> JsonLdSerializer<W> {
 
 impl<W, L> JsonLdSerializer<W, L> {
     /// Build a new JSON-LD serializer writing to `write`, with the given options.
-    pub fn new_with_options(target: W, options: JsonLdOptions<L>) -> Self {
-        JsonLdSerializer { target, options }
+    pub const fn new_with_options(target: W, options: JsonLdOptions<L>) -> Self {
+        Self { options, target }
     }
 
     /// Borrow this serializer's options.
-    pub fn options(&self) -> &JsonLdOptions<L> {
+    pub const fn options(&self) -> &JsonLdOptions<L> {
         &self.options
     }
 
@@ -115,25 +115,25 @@ pub struct JsonTarget(JsonValue<()>);
 impl Jsonifier {
     /// Create a new serializer which targets a [`JsonValue`].
     #[inline]
-    pub fn new_jsonifier() -> Self {
-        JsonLdSerializer::new(JsonTarget(JsonValue::Null))
+    #[must_use] pub fn new_jsonifier() -> Self {
+        Self::new(JsonTarget(JsonValue::Null))
     }
 }
 
 impl<L> Jsonifier<L> {
     /// Create a new serializer which targets a [`JsonValue`] with a custom options.
     #[inline]
-    pub fn new_jsonifier_with_options(options: JsonLdOptions<L>) -> Self {
-        JsonLdSerializer::new_with_options(JsonTarget(JsonValue::Null), options)
+    pub const fn new_jsonifier_with_options(options: JsonLdOptions<L>) -> Self {
+        Self::new_with_options(JsonTarget(JsonValue::Null), options)
     }
 
-    /// Get a reference to the converted JsonValue
+    /// Get a reference to the converted `JsonValue`
     #[inline]
-    pub fn as_json(&self) -> &JsonValue<()> {
+    pub const fn as_json(&self) -> &JsonValue<()> {
         &self.target.0
     }
 
-    /// Extract the converted JsonValue
+    /// Extract the converted `JsonValue`
     #[inline]
     pub fn to_json(&mut self) -> JsonValue<()> {
         let mut ret = JsonValue::Null;
@@ -165,16 +165,16 @@ pub type JsonLdStringifier<L = NoLoader> = JsonLdSerializer<Vec<u8>, L>;
 impl JsonLdStringifier<NoLoader> {
     /// Create a new serializer which targets a string.
     #[inline]
-    pub fn new_stringifier() -> Self {
-        JsonLdSerializer::new(Vec::new())
+    #[must_use] pub fn new_stringifier() -> Self {
+        Self::new(Vec::new())
     }
 }
 
 impl<L> JsonLdStringifier<L> {
     /// Create a new serializer which targets a string with a custom options.
     #[inline]
-    pub fn new_stringifier_with_options(options: JsonLdOptions<L>) -> Self {
-        JsonLdSerializer::new_with_options(Vec::new(), options)
+    pub const fn new_stringifier_with_options(options: JsonLdOptions<L>) -> Self {
+        Self::new_with_options(Vec::new(), options)
     }
 }
 

--- a/jsonld/src/serializer.rs
+++ b/jsonld/src/serializer.rs
@@ -115,7 +115,8 @@ pub struct JsonTarget(JsonValue<()>);
 impl Jsonifier {
     /// Create a new serializer which targets a [`JsonValue`].
     #[inline]
-    #[must_use] pub fn new_jsonifier() -> Self {
+    #[must_use]
+    pub fn new_jsonifier() -> Self {
         Self::new(JsonTarget(JsonValue::Null))
     }
 }
@@ -165,7 +166,8 @@ pub type JsonLdStringifier<L = NoLoader> = JsonLdSerializer<Vec<u8>, L>;
 impl JsonLdStringifier<NoLoader> {
     /// Create a new serializer which targets a string.
     #[inline]
-    #[must_use] pub fn new_stringifier() -> Self {
+    #[must_use]
+    pub fn new_stringifier() -> Self {
         Self::new(Vec::new())
     }
 }

--- a/jsonld/src/serializer/engine.rs
+++ b/jsonld/src/serializer/engine.rs
@@ -1,6 +1,10 @@
 use super::rdf_object::RdfObject;
 use crate::error::JsonLdError;
-use crate::options::{ProcessingMode::{JsonLd1_0, JsonLd1_1}, JsonLdOptions, RdfDirection};
+use crate::options::{
+    JsonLdOptions,
+    ProcessingMode::{JsonLd1_0, JsonLd1_1},
+    RdfDirection,
+};
 use crate::util_traits::{HashMapUtil, QuadJsonLdUtil, TermJsonLdUtil, VecUtil};
 use json_syntax::object::Object;
 use json_syntax::{Parse, Value as JsonValue};
@@ -122,7 +126,9 @@ impl<'a, L> Engine<'a, L> {
     where
         T: Term,
     {
-        if o.kind() == TermKind::Literal { RdfObject::try_from_term(o).unwrap() } else {
+        if o.kind() == TermKind::Literal {
+            RdfObject::try_from_term(o).unwrap()
+        } else {
             let o_id = o.as_id();
             RdfObject::Node(self.index(g_id.to_string(), o_id.clone()), o_id)
         }

--- a/jsonld/src/serializer/rdf_object.rs
+++ b/jsonld/src/serializer/rdf_object.rs
@@ -1,7 +1,7 @@
-//! A private enum type used internally by JsonLdSerializer
+//! A private enum type used internally by `JsonLdSerializer`
 use sophia_api::term::{IriRef, LanguageTag, TermKind, TryFromTerm};
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum RdfObject {
     LangString(Box<str>, LanguageTag<Box<str>>),
     TypedLiteral(Box<str>, IriRef<Box<str>>),
@@ -9,33 +9,33 @@ pub enum RdfObject {
 }
 
 impl RdfObject {
-    pub fn is_literal(&self) -> bool {
+    pub const fn is_literal(&self) -> bool {
         matches!(
             self,
-            RdfObject::LangString(..) | RdfObject::TypedLiteral(..)
+            Self::LangString(..) | Self::TypedLiteral(..)
         )
     }
-    pub fn is_node(&self) -> bool {
-        matches!(self, RdfObject::Node(..))
+    pub const fn is_node(&self) -> bool {
+        matches!(self, Self::Node(..))
     }
     pub fn is_iri(&self) -> bool {
-        matches!(self, RdfObject::Node(_, id) if !id.starts_with("_:"))
+        matches!(self, Self::Node(_, id) if !id.starts_with("_:"))
     }
     pub fn eq_node(&self, other_id: &str) -> bool {
-        matches!(self, RdfObject::Node(_, id) if id.as_ref()==other_id)
+        matches!(self, Self::Node(_, id) if id.as_ref()==other_id)
     }
     pub fn as_str(&self) -> &str {
         match self {
-            RdfObject::LangString(lit, _) => lit.as_ref(),
-            RdfObject::TypedLiteral(lit, _) => lit.as_ref(),
-            RdfObject::Node(_, id) => id,
+            Self::LangString(lit, _) => lit.as_ref(),
+            Self::TypedLiteral(lit, _) => lit.as_ref(),
+            Self::Node(_, id) => id,
         }
     }
 }
 
 impl From<(usize, String)> for RdfObject {
     fn from(other: (usize, String)) -> Self {
-        RdfObject::Node(other.0, other.1.into())
+        Self::Node(other.0, other.1.into())
     }
 }
 
@@ -48,10 +48,10 @@ impl TryFromTerm for RdfObject {
                 let lex: Box<str> = term.lexical_form().unwrap().into();
                 if let Some(tag) = term.language_tag() {
                     let tag = tag.map_unchecked(Into::into);
-                    Ok(RdfObject::LangString(lex, tag))
+                    Ok(Self::LangString(lex, tag))
                 } else {
                     let dt = term.datatype().unwrap().map_unchecked(Into::into);
-                    Ok(RdfObject::TypedLiteral(lex, dt))
+                    Ok(Self::TypedLiteral(lex, dt))
                 }
             }
             _ => Err(RdfObjectError {}),

--- a/jsonld/src/serializer/rdf_object.rs
+++ b/jsonld/src/serializer/rdf_object.rs
@@ -10,10 +10,7 @@ pub enum RdfObject {
 
 impl RdfObject {
     pub const fn is_literal(&self) -> bool {
-        matches!(
-            self,
-            Self::LangString(..) | Self::TypedLiteral(..)
-        )
+        matches!(self, Self::LangString(..) | Self::TypedLiteral(..))
     }
     pub const fn is_node(&self) -> bool {
         matches!(self, Self::Node(..))

--- a/jsonld/src/util_traits.rs
+++ b/jsonld/src/util_traits.rs
@@ -1,7 +1,7 @@
-//! Utility traits used internally by JsonLdSerializer
+//! Utility traits used internally by `JsonLdSerializer`
 use sophia_api::quad::Quad;
-use sophia_api::term::{Term, TermKind::*};
-use std::collections::hash_map::Entry::*;
+use sophia_api::term::{Term, TermKind::{BlankNode, Iri, Literal}};
+use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::collections::HashMap;
 
 pub trait TermJsonLdUtil {
@@ -44,7 +44,7 @@ impl<Q: Quad> QuadJsonLdUtil for Q {
         self.s().is_subject()
             && self.p().is_iri()
             && self.o().is_object()
-            && self.g().map(|g| g.is_subject()).unwrap_or(true)
+            && self.g().map_or(true, |g| g.is_subject())
     }
 }
 

--- a/jsonld/src/util_traits.rs
+++ b/jsonld/src/util_traits.rs
@@ -1,6 +1,9 @@
 //! Utility traits used internally by `JsonLdSerializer`
 use sophia_api::quad::Quad;
-use sophia_api::term::{Term, TermKind::{BlankNode, Iri, Literal}};
+use sophia_api::term::{
+    Term,
+    TermKind::{BlankNode, Iri, Literal},
+};
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::collections::HashMap;
 

--- a/jsonld/src/vocabulary.rs
+++ b/jsonld/src/vocabulary.rs
@@ -112,7 +112,7 @@ impl LanguageTagVocabularyMut for ArcVoc {
 
 /// Self-explanatory bnode index for JSON-LD processing.
 ///
-/// We are not using Sophia's BnodeId because it does not allocate the '_:'.
+/// We are not using Sophia's `BnodeId` because it does not allocate the '_:'.
 /// Since instances of this type are always created via [`ArcVoc`] from a valid bnode identifier,
 /// we don't need to implement any validity check.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]

--- a/resource/src/lib.rs
+++ b/resource/src/lib.rs
@@ -83,7 +83,7 @@ mod test {
         .unwrap()
     }
 
-    /// Test impl of TypedResource
+    /// Test impl of `TypedResource`
     pub struct WithId(Resource<MyGraph, LocalLoader>);
 
     impl TryFrom<Resource<MyGraph, LocalLoader>> for WithId {

--- a/resource/src/loader/_error.rs
+++ b/resource/src/loader/_error.rs
@@ -25,7 +25,8 @@ pub enum LoaderError {
 
 impl LoaderError {
     /// Return the IRI that caused this error
-    #[must_use] pub fn iri(&self) -> IriBuf {
+    #[must_use]
+    pub fn iri(&self) -> IriBuf {
         let iri = match self {
             Self::UnsupportedIri(iri, _) => iri,
             Self::NotFound(iri) => iri,

--- a/resource/src/loader/_error.rs
+++ b/resource/src/loader/_error.rs
@@ -25,13 +25,13 @@ pub enum LoaderError {
 
 impl LoaderError {
     /// Return the IRI that caused this error
-    pub fn iri(&self) -> IriBuf {
+    #[must_use] pub fn iri(&self) -> IriBuf {
         let iri = match self {
-            LoaderError::UnsupportedIri(iri, _) => iri,
-            LoaderError::NotFound(iri) => iri,
-            LoaderError::IoError(iri, _) => iri,
-            LoaderError::CantGuessSyntax(iri) => iri,
-            LoaderError::ParseError(iri, _) => iri,
+            Self::UnsupportedIri(iri, _) => iri,
+            Self::NotFound(iri) => iri,
+            Self::IoError(iri, _) => iri,
+            Self::CantGuessSyntax(iri) => iri,
+            Self::ParseError(iri, _) => iri,
         };
         iri.clone()
     }

--- a/resource/src/loader/_local.rs
+++ b/resource/src/loader/_local.rs
@@ -1,4 +1,4 @@
-use super::{util::*, *};
+use super::{util::{IriBuf, iri_buf}, Loader, LoaderError};
 use sophia_iri::Iri;
 use std::borrow::Borrow;
 use std::fmt::Debug;
@@ -24,7 +24,7 @@ impl LocalLoader {
             .into_iter()
             .map(|(iri, path)| Self::check(iri, path))
             .collect::<Result<Vec<(IriBuf, PathBuf)>, LocalLoaderError>>()?;
-        Ok(LocalLoader {
+        Ok(Self {
             caches: checked_caches,
         })
     }
@@ -41,7 +41,7 @@ impl LocalLoader {
     }
 
     /// Wrap this loader into an `Arc<Loader>`.
-    pub fn arced(self) -> Arc<Self> {
+    #[must_use] pub fn arced(self) -> Arc<Self> {
         Arc::new(self)
     }
 
@@ -94,7 +94,7 @@ impl Loader for LocalLoader {
                                 #[cfg(feature = "xml")]
                                 "rdf",
                             ] {
-                                let alt = Iri::new_unchecked(format!("{}.{}", iri, ext));
+                                let alt = Iri::new_unchecked(format!("{iri}.{ext}"));
                                 if let Ok(res) = self.get(alt) {
                                     return Ok(res);
                                 }

--- a/resource/src/loader/_local.rs
+++ b/resource/src/loader/_local.rs
@@ -1,4 +1,7 @@
-use super::{util::{IriBuf, iri_buf}, Loader, LoaderError};
+use super::{
+    util::{iri_buf, IriBuf},
+    Loader, LoaderError,
+};
 use sophia_iri::Iri;
 use std::borrow::Borrow;
 use std::fmt::Debug;
@@ -41,7 +44,8 @@ impl LocalLoader {
     }
 
     /// Wrap this loader into an `Arc<Loader>`.
-    #[must_use] pub fn arced(self) -> Arc<Self> {
+    #[must_use]
+    pub fn arced(self) -> Arc<Self> {
         Arc::new(self)
     }
 

--- a/resource/src/loader/_no.rs
+++ b/resource/src/loader/_no.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::{Loader, LoaderError};
 use sophia_iri::Iri;
 use std::borrow::Borrow;
 use std::fmt::Debug;

--- a/resource/src/resource/_error.rs
+++ b/resource/src/resource/_error.rs
@@ -81,15 +81,15 @@ where
     /// (*not* the resource from which it was discovered).
     pub fn resource_id(&self) -> SimpleTerm {
         match self {
-            ResourceError::IriNotAbsolute(iriref) => iriref.as_simple(),
-            ResourceError::LoaderError(err) => err.iri().into_term(),
-            ResourceError::GraphError { id, .. } => id.as_simple(),
-            ResourceError::NoValueFor { id, .. } => id.as_simple(),
-            ResourceError::UnexpectedMultipleValueFor { id, .. } => id.as_simple(),
-            ResourceError::MissingType { id, .. } => id.as_simple(),
-            ResourceError::UnexpectedKind { id, .. } => id.as_simple(),
-            ResourceError::UnexpectedDatatype { id, .. } => id.as_simple(),
-            ResourceError::UnexpectedValue { id, .. } => id.as_simple(),
+            Self::IriNotAbsolute(iriref) => iriref.as_simple(),
+            Self::LoaderError(err) => err.iri().into_term(),
+            Self::GraphError { id, .. } => id.as_simple(),
+            Self::NoValueFor { id, .. } => id.as_simple(),
+            Self::UnexpectedMultipleValueFor { id, .. } => id.as_simple(),
+            Self::MissingType { id, .. } => id.as_simple(),
+            Self::UnexpectedKind { id, .. } => id.as_simple(),
+            Self::UnexpectedDatatype { id, .. } => id.as_simple(),
+            Self::UnexpectedValue { id, .. } => id.as_simple(),
         }
     }
 }
@@ -99,7 +99,7 @@ where
     E: Error + Send + Sync + 'static,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/resource/src/resource/_iter.rs
+++ b/resource/src/resource/_iter.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use super::{Resource, ResourceError::NoValueFor, ResourceError, ResourceResult, TypedResource};
+use super::{Resource, ResourceError, ResourceError::NoValueFor, ResourceResult, TypedResource};
 use crate::Loader;
 use sophia_api::{graph::CollectibleGraph, prelude::*, term::SimpleTerm};
 

--- a/resource/src/resource/_iter.rs
+++ b/resource/src/resource/_iter.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use super::{Resource, ResourceError::NoValueFor, *};
+use super::{Resource, ResourceError::NoValueFor, ResourceError, ResourceResult, TypedResource};
 use crate::Loader;
 use sophia_api::{graph::CollectibleGraph, prelude::*, term::SimpleTerm};
 
@@ -19,7 +19,7 @@ impl<G: Graph, L> LadderTermIterator<G, L> {
     /// `start` is expected to be `Some(Ok(first_blank_node));
     /// if it is `Some(Err(_))`, the iterator will yield this error;
     /// if it is `None`, the iterator will be empty.
-    pub fn new(
+    pub const fn new(
         start: Option<ResourceResult<Resource<G, L>, G>>,
         value: SimpleTerm<'static>,
         next: SimpleTerm<'static>,

--- a/resource/src/resource/_struct.rs
+++ b/resource/src/resource/_struct.rs
@@ -601,7 +601,7 @@ impl<G, L> Clone for Resource<G, L> {
     }
 }
 
-pub fn to_iri<T: Borrow<str>>(iri_ref: IriRef<T>) -> Result<Iri<T>, IriRef<Box<str>>> {
+pub(crate) fn to_iri<T: Borrow<str>>(iri_ref: IriRef<T>) -> Result<Iri<T>, IriRef<Box<str>>> {
     if is_absolute_iri_ref(iri_ref.as_str()) {
         Ok(Iri::new_unchecked(iri_ref.unwrap()))
     } else {

--- a/resource/src/resource/_struct.rs
+++ b/resource/src/resource/_struct.rs
@@ -8,7 +8,13 @@ use sophia_iri::is_absolute_iri_ref;
 use std::borrow::Borrow;
 use std::sync::Arc;
 
-use super::{ResourceError::{GraphError, IriNotAbsolute, LoaderError, NoValueFor, UnexpectedMultipleValueFor}, LadderResourceIterator, LadderTermIterator, LadderTypedIterator, ResourceError, ResourceResult, TypedResource};
+use super::{
+    LadderResourceIterator, LadderTermIterator, LadderTypedIterator, ResourceError,
+    ResourceError::{
+        GraphError, IriNotAbsolute, LoaderError, NoValueFor, UnexpectedMultipleValueFor,
+    },
+    ResourceResult, TypedResource,
+};
 
 /// A [`Resource`] represents a specific node in a given graph.
 #[derive(Debug)]
@@ -36,22 +42,26 @@ where
     }
 
     /// The identifying term of this resource
-    #[must_use] pub const fn id(&self) -> &SimpleTerm<'static> {
+    #[must_use]
+    pub const fn id(&self) -> &SimpleTerm<'static> {
         &self.id
     }
 
     /// The URL of the underlying graph of this resource
-    #[must_use] pub const fn base(&self) -> Option<&Iri<String>> {
+    #[must_use]
+    pub const fn base(&self) -> Option<&Iri<String>> {
         self.base.as_ref()
     }
 
     /// The underlying graph of this resource
-    #[must_use] pub const fn graph(&self) -> &Arc<G> {
+    #[must_use]
+    pub const fn graph(&self) -> &Arc<G> {
         &self.graph
     }
 
     /// The loader used to load neighbouring resources
-    #[must_use] pub const fn loader(&self) -> &Arc<L> {
+    #[must_use]
+    pub const fn loader(&self) -> &Arc<L> {
         &self.loader
     }
 

--- a/rio/src/model.rs
+++ b/rio/src/model.rs
@@ -109,9 +109,7 @@ impl<'a> Term for Trusted<Literal<'a>> {
 fn lexical_form(l: Literal) -> MownStr {
     use Literal::{LanguageTaggedString, Simple, Typed};
     let value = match l {
-        Simple { value } => value,
-        LanguageTaggedString { value, .. } => value,
-        Typed { value, .. } => value,
+        LanguageTaggedString { value, .. } | Typed { value, .. } | Simple { value } => value,
     };
     value.into()
 }

--- a/rio/src/model.rs
+++ b/rio/src/model.rs
@@ -8,7 +8,10 @@
 //! which ensures the validity of the underlying data.
 //!
 //! The [`Trusted`] wrapper is used to materialize the fact that we trust the underlying data of Rio types.
-use rio_api::model::{Quad as RioQuad, Term as RioTerm, Triple as RioTriple, BlankNode, GeneralizedQuad, GeneralizedTerm, GraphName, Literal, NamedNode, Variable};
+use rio_api::model::{
+    BlankNode, GeneralizedQuad, GeneralizedTerm, GraphName, Literal, NamedNode, Quad as RioQuad,
+    Term as RioTerm, Triple as RioTriple, Variable,
+};
 use sophia_api::ns::{rdf, xsd};
 use sophia_api::quad::{QBorrowTerm, Quad, Spog};
 use sophia_api::term::{BnodeId, LanguageTag, Term, TermKind, VarName};

--- a/rio/src/model.rs
+++ b/rio/src/model.rs
@@ -8,7 +8,7 @@
 //! which ensures the validity of the underlying data.
 //!
 //! The [`Trusted`] wrapper is used to materialize the fact that we trust the underlying data of Rio types.
-use rio_api::model::{Quad as RioQuad, Term as RioTerm, Triple as RioTriple, *};
+use rio_api::model::{Quad as RioQuad, Term as RioTerm, Triple as RioTriple, BlankNode, GeneralizedQuad, GeneralizedTerm, GraphName, Literal, NamedNode, Variable};
 use sophia_api::ns::{rdf, xsd};
 use sophia_api::quad::{QBorrowTerm, Quad, Spog};
 use sophia_api::term::{BnodeId, LanguageTag, Term, TermKind, VarName};
@@ -104,7 +104,7 @@ impl<'a> Term for Trusted<Literal<'a>> {
 }
 
 fn lexical_form(l: Literal) -> MownStr {
-    use Literal::*;
+    use Literal::{LanguageTaggedString, Simple, Typed};
     let value = match l {
         Simple { value } => value,
         LanguageTaggedString { value, .. } => value,
@@ -114,7 +114,7 @@ fn lexical_form(l: Literal) -> MownStr {
 }
 
 fn datatype(l: Literal) -> IriRef<MownStr> {
-    use Literal::*;
+    use Literal::{LanguageTaggedString, Simple, Typed};
     let dt = match l {
         Simple { .. } => xsd::string.iriref(),
         LanguageTaggedString { .. } => rdf::langString.iriref(),
@@ -206,7 +206,7 @@ impl<'a> Term for Trusted<GraphName<'a>> {
     type BorrowTerm<'x> = Self where Self: 'x;
 
     fn kind(&self) -> TermKind {
-        use GraphName::*;
+        use GraphName::{BlankNode, NamedNode};
         match self.0 {
             NamedNode(_) => TermKind::Iri,
             BlankNode(_) => TermKind::BlankNode,
@@ -238,7 +238,7 @@ impl<'a> Term for Trusted<RioTerm<'a>> {
     type BorrowTerm<'x> = Self where Self: 'x;
 
     fn kind(&self) -> TermKind {
-        use RioTerm::*;
+        use RioTerm::{BlankNode, Literal, NamedNode, Triple};
         match self.0 {
             NamedNode(_) => TermKind::Iri,
             BlankNode(_) => TermKind::BlankNode,
@@ -314,7 +314,7 @@ impl<'a> Term for Trusted<GeneralizedTerm<'a>> {
     type BorrowTerm<'x> = Self where Self: 'x;
 
     fn kind(&self) -> TermKind {
-        use GeneralizedTerm::*;
+        use GeneralizedTerm::{BlankNode, Literal, NamedNode, Triple, Variable};
         match self.0 {
             NamedNode(_) => TermKind::Iri,
             BlankNode(_) => TermKind::BlankNode,
@@ -526,7 +526,7 @@ mod test {
 
     #[test]
     fn blank_node() {
-        assert_consistent_term_impl(&Trusted(BlankNode { id: "foo" }))
+        assert_consistent_term_impl(&Trusted(BlankNode { id: "foo" }));
     }
 
     #[test]
@@ -595,7 +595,7 @@ mod test {
     #[test]
     fn graph_name_blank_node() {
         let t: GraphName = BlankNode { id: "foo" }.into();
-        assert_consistent_term_impl(&Trusted(t))
+        assert_consistent_term_impl(&Trusted(t));
     }
 
     #[test]
@@ -607,7 +607,7 @@ mod test {
     #[test]
     fn term_blank_node() {
         let t: RioTerm = BlankNode { id: "foo" }.into();
-        assert_consistent_term_impl(&Trusted(t))
+        assert_consistent_term_impl(&Trusted(t));
     }
 
     #[test]
@@ -661,7 +661,7 @@ mod test {
     #[test]
     fn gterm_blank_node() {
         let t: RioTerm = BlankNode { id: "foo" }.into();
-        assert_consistent_term_impl(&Trusted(t))
+        assert_consistent_term_impl(&Trusted(t));
     }
 
     #[test]
@@ -715,6 +715,6 @@ mod test {
     #[test]
     fn gterm_variable() {
         let t: GeneralizedTerm = Variable { name: "foo" }.into();
-        assert_consistent_term_impl(&Trusted(t))
+        assert_consistent_term_impl(&Trusted(t));
     }
 }

--- a/rio/src/parser.rs
+++ b/rio/src/parser.rs
@@ -9,7 +9,11 @@
 use std::error::Error;
 
 use crate::model::Trusted;
-use sophia_api::source::{StreamError, StreamError::{SinkError, SourceError}, StreamResult};
+use sophia_api::source::{
+    StreamError,
+    StreamError::{SinkError, SourceError},
+    StreamResult,
+};
 
 /// Wrap a Rio [`TriplesParser`](rio_api::parser::TriplesParser)
 /// into a Sophia [`TripleSource`](sophia_api::source::TripleSource).

--- a/rio/src/parser.rs
+++ b/rio/src/parser.rs
@@ -9,7 +9,7 @@
 use std::error::Error;
 
 use crate::model::Trusted;
-use sophia_api::source::{StreamError, StreamError::*, StreamResult};
+use sophia_api::source::{StreamError, StreamError::{SinkError, SourceError}, StreamResult};
 
 /// Wrap a Rio [`TriplesParser`](rio_api::parser::TriplesParser)
 /// into a Sophia [`TripleSource`](sophia_api::source::TripleSource).
@@ -111,12 +111,12 @@ where
 }
 
 /// This intermediate type is required,
-/// because Rio requires that the error type of triple_handler/quad_handler
+/// because Rio requires that the error type of `triple_handler/quad_handler`
 /// implement From<TurtleError> (or whatever Rio-specific error returned by the parser).
 ///
 /// This is costless, though,
-/// because RioStreamError's internal representation is identical to StreamError,
-/// so the final type conversion performed by into_stream_error is actually
+/// because `RioStreamError`'s internal representation is identical to `StreamError`,
+/// so the final type conversion performed by `into_stream_error` is actually
 /// just for pleasing the compiler.
 enum RioStreamError<E1, E2> {
     /// Equivalent to [`StreamError::SourceError`]
@@ -130,7 +130,7 @@ where
     E2: Error + Send + Sync + 'static,
 {
     fn from(other: E1) -> Self {
-        RioStreamError::Source(other)
+        Self::Source(other)
     }
 }
 impl<E1, E2> From<RioStreamError<E1, E2>> for StreamError<E1, E2>

--- a/rio/src/serializer.rs
+++ b/rio/src/serializer.rs
@@ -76,7 +76,7 @@ where
     })
 }
 
-/// Convert this triple of SimpleTerms to a RioTriple if possible
+/// Convert this triple of `SimpleTerms` to a `RioTriple` if possible
 /// (i.e. if it is a strict RDF triple)
 fn convert_triple<'a>(
     t: &'a [SimpleTerm<'a>; 3],
@@ -147,10 +147,10 @@ enum Stack<T> {
     Empty,
     Node(Box<(T, Stack<T>)>),
 }
-use Stack::*;
+use Stack::{Empty, Node};
 impl<T> Stack<T> {
     /// Get the triple at the head of the stack.
-    fn head(&self) -> Option<&T> {
+    const fn head(&self) -> Option<&T> {
         match self {
             Empty => None,
             Node(b) => Some(&b.0),

--- a/sophia/examples/canonicalize.rs
+++ b/sophia/examples/canonicalize.rs
@@ -3,13 +3,13 @@
 //! using the [RDFC-1.0] canonicalization algorithm.
 //!
 //! Parameters of the RDFC-1.0 can be provided via the following environment variables:
-//! * SOPHIA_RDFC10_DEPTH_FACTOR
-//! * SOPHIA_RDFC10_PERMUTATION_LIMIT
+//! * `SOPHIA_RDFC10_DEPTH_FACTOR`
+//! * `SOPHIA_RDFC10_PERMUTATION_LIMIT`
 //!
 //! [N-Quads]: https://www.w3.org/TR/n-quads/
 //! [RDFC-1.0]: https://www.w3.org/TR/rdf-canon/
 
-use std::env::{var, VarError::*};
+use std::env::{var, VarError::NotPresent};
 use std::io::{stdin, stdout, BufReader, BufWriter};
 
 use sophia::api::prelude::*;

--- a/sophia/examples/jsonld-context.rs
+++ b/sophia/examples/jsonld-context.rs
@@ -1,4 +1,4 @@
-//! Convert a JSON-LD file to TriG, using an optional external context.
+//! Convert a JSON-LD file to `TriG`, using an optional external context.
 //!
 //! usage: cargo run --example jsonld-context <JSON-LD file> [context file]
 //!
@@ -20,14 +20,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let context_path = args.next();
     if let Some(context_path) = &context_path {
         eprintln!(
-            "Loading {} with @context from {}",
-            json_ld_path, context_path
+            "Loading {json_ld_path} with @context from {context_path}"
         );
     } else {
-        eprintln!("Loading {}", json_ld_path);
+        eprintln!("Loading {json_ld_path}");
     }
     let json_str = std::fs::read_to_string(&json_ld_path)
-        .unwrap_or_else(|e| panic!("Could not read file {}: {}", json_ld_path, e));
+        .unwrap_or_else(|e| panic!("Could not read file {json_ld_path}: {e}"));
 
     let mut options = JsonLdOptions::new().with_expansion_policy(Policy::Standard);
     if let Some(context_path) = context_path {

--- a/sophia/examples/jsonld-context.rs
+++ b/sophia/examples/jsonld-context.rs
@@ -19,9 +19,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let json_ld_path = args.nth(1).expect("Missing jsonld file.");
     let context_path = args.next();
     if let Some(context_path) = &context_path {
-        eprintln!(
-            "Loading {json_ld_path} with @context from {context_path}"
-        );
+        eprintln!("Loading {json_ld_path} with @context from {context_path}");
     } else {
         eprintln!("Loading {json_ld_path}");
     }

--- a/sophia/examples/parse.rs
+++ b/sophia/examples/parse.rs
@@ -83,8 +83,8 @@ fn main() {
         "gtrig" => dump_quads(input, GTriGParser { base }),
         #[cfg(feature = "jsonld")]
         "json-ld" | "jsonld" => {
-            let options = JsonLdOptions::new()
-                .with_base(base.unwrap().map_unchecked(std::sync::Arc::from));
+            let options =
+                JsonLdOptions::new().with_base(base.unwrap().map_unchecked(std::sync::Arc::from));
             let loader_factory = sophia::jsonld::loader::FileUrlLoader::default;
             #[cfg(feature = "http_client")]
             let loader_factory = || {

--- a/sophia/examples/parse.rs
+++ b/sophia/examples/parse.rs
@@ -5,7 +5,7 @@
 //! Alternatively, the input file name can be provided as a second argument,
 //! which will also set the base IRI to the corresponding file: URL.
 //!
-//! The base IRI can be overridden via the environment variable SOPHIA_BASE.
+//! The base IRI can be overridden via the environment variable `SOPHIA_BASE`.
 //!
 //! Recognized formats are:
 //! - [`ntriples`](https://www.w3.org/TR/n-triples/) (alias `nt`)
@@ -46,13 +46,13 @@ fn main() {
             eprintln!("Cannot guess format of stdin");
             std::process::exit(-2);
         };
-        format = match filename.rsplit(".").next() {
+        format = match filename.rsplit('.').next() {
             Some("nt") => "ntriples",
             Some("nq") => "nquads",
             Some("ttl") => "turtle",
             Some("trig") => "trig",
-            Some("jsonld") | Some("json") => "jsonld",
-            Some("rdf") | Some("xml") => "rdfxml",
+            Some("jsonld" | "json") => "jsonld",
+            Some("rdf" | "xml") => "rdfxml",
             _ => {
                 eprintln!("Cannot guess format of {filename}");
                 std::process::exit(-3);
@@ -84,7 +84,7 @@ fn main() {
         #[cfg(feature = "jsonld")]
         "json-ld" | "jsonld" => {
             let options = JsonLdOptions::new()
-                .with_base(base.clone().unwrap().map_unchecked(std::sync::Arc::from));
+                .with_base(base.unwrap().map_unchecked(std::sync::Arc::from));
             let loader_factory = sophia::jsonld::loader::FileUrlLoader::default;
             #[cfg(feature = "http_client")]
             let loader_factory = || {
@@ -99,12 +99,12 @@ fn main() {
         #[cfg(feature = "xml")]
         "rdfxml" | "rdf" => dump_triples(input, RdfXmlParser { base }),
         _ => {
-            eprintln!("Unrecognized format: {}", format);
+            eprintln!("Unrecognized format: {format}");
             std::process::exit(-1);
         }
     };
     if let Err(msg) = res {
-        eprintln!("{}", msg);
+        eprintln!("{msg}");
         std::process::exit(1);
     }
 }
@@ -116,8 +116,8 @@ fn dump_triples<P: TripleParser<Input>>(input: Input, p: P) -> Result<(), String
     let mut ser = NtSerializer::new(output);
     match ser.serialize_triples(triple_source) {
         Ok(_) => Ok(()),
-        Err(SourceError(e)) => Err(format!("Error while parsing input: {}", e)),
-        Err(SinkError(e)) => Err(format!("Error while writing quads: {}", e)),
+        Err(SourceError(e)) => Err(format!("Error while parsing input: {e}")),
+        Err(SinkError(e)) => Err(format!("Error while writing quads: {e}")),
     }
 }
 
@@ -128,8 +128,8 @@ fn dump_quads<P: QuadParser<Input>>(input: Input, p: P) -> Result<(), String> {
     let mut ser = NqSerializer::new(output);
     match ser.serialize_quads(quad_source) {
         Ok(_) => Ok(()),
-        Err(SourceError(e)) => Err(format!("Error while parsing input: {}", e)),
-        Err(SinkError(e)) => Err(format!("Error while writing quads: {}", e)),
+        Err(SourceError(e)) => Err(format!("Error while parsing input: {e}")),
+        Err(SinkError(e)) => Err(format!("Error while writing quads: {e}")),
     }
 }
 
@@ -150,8 +150,8 @@ impl Input {
 impl Read for Input {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         match self {
-            Input::Stdin(b) => b.read(buf),
-            Input::File(b) => b.read(buf),
+            Self::Stdin(b) => b.read(buf),
+            Self::File(b) => b.read(buf),
         }
     }
 }
@@ -159,15 +159,15 @@ impl Read for Input {
 impl BufRead for Input {
     fn fill_buf(&mut self) -> std::io::Result<&[u8]> {
         match self {
-            Input::Stdin(b) => b.fill_buf(),
-            Input::File(b) => b.fill_buf(),
+            Self::Stdin(b) => b.fill_buf(),
+            Self::File(b) => b.fill_buf(),
         }
     }
 
     fn consume(&mut self, amt: usize) {
         match self {
-            Input::Stdin(b) => b.consume(amt),
-            Input::File(b) => b.consume(amt),
+            Self::Stdin(b) => b.consume(amt),
+            Self::File(b) => b.consume(amt),
         }
     }
 }

--- a/sophia/examples/serialize.rs
+++ b/sophia/examples/serialize.rs
@@ -70,12 +70,12 @@ fn main() {
             serialize_triples(quad_source, ser)
         }
         _ => {
-            eprintln!("Unrecognized format: {}", format);
+            eprintln!("Unrecognized format: {format}");
             std::process::exit(-1);
         }
     };
     if let Err(msg) = res {
-        eprintln!("{}", msg);
+        eprintln!("{msg}");
         std::process::exit(1);
     }
 }
@@ -87,8 +87,8 @@ fn serialize_triples<Q: QuadSource, S: TripleSerializer>(
     let triple_source = quad_source.filter_quads(|q| q.g().is_none()).to_triples();
     match ser.serialize_triples(triple_source) {
         Ok(_) => Ok(()),
-        Err(SourceError(e)) => Err(format!("Error while parsing input: {}", e)),
-        Err(SinkError(e)) => Err(format!("Error while serializing triples: {}", e)),
+        Err(SourceError(e)) => Err(format!("Error while parsing input: {e}")),
+        Err(SinkError(e)) => Err(format!("Error while serializing triples: {e}")),
     }
 }
 
@@ -98,7 +98,7 @@ fn serialize_quads<Q: QuadSource, S: QuadSerializer>(
 ) -> Result<(), String> {
     match ser.serialize_quads(quad_source) {
         Ok(_) => Ok(()),
-        Err(SourceError(e)) => Err(format!("Error while parsing input: {}", e)),
-        Err(SinkError(e)) => Err(format!("Error while serializing quads: {}", e)),
+        Err(SourceError(e)) => Err(format!("Error while parsing input: {e}")),
+        Err(SinkError(e)) => Err(format!("Error while serializing quads: {e}")),
     }
 }

--- a/term/src/_generic.rs
+++ b/term/src/_generic.rs
@@ -24,8 +24,7 @@ impl<T: Borrow<str>> GenericLiteral<T> {
     /// The [lexical form](https://www.w3.org/TR/rdf11-concepts/#dfn-lexical-form) of this literal
     pub fn get_lexical_form(&self) -> &str {
         match self {
-            Self::Typed(lex, ..) => lex,
-            Self::LanguageString(lex, ..) => lex,
+            Self::LanguageString(lex, ..) | Self::Typed(lex, ..) => lex,
         }
         .borrow()
     }

--- a/term/src/_generic.rs
+++ b/term/src/_generic.rs
@@ -24,8 +24,8 @@ impl<T: Borrow<str>> GenericLiteral<T> {
     /// The [lexical form](https://www.w3.org/TR/rdf11-concepts/#dfn-lexical-form) of this literal
     pub fn get_lexical_form(&self) -> &str {
         match self {
-            GenericLiteral::Typed(lex, ..) => lex,
-            GenericLiteral::LanguageString(lex, ..) => lex,
+            Self::Typed(lex, ..) => lex,
+            Self::LanguageString(lex, ..) => lex,
         }
         .borrow()
     }
@@ -33,16 +33,16 @@ impl<T: Borrow<str>> GenericLiteral<T> {
     /// The [datatype](https://www.w3.org/TR/rdf11-concepts/#dfn-datatype-iri) of this literal
     pub fn get_datatype(&self) -> IriRef<&str> {
         match self {
-            GenericLiteral::Typed(_, dt) => dt.as_ref(),
-            GenericLiteral::LanguageString(..) => RDF_LANG_STRING.as_ref(),
+            Self::Typed(_, dt) => dt.as_ref(),
+            Self::LanguageString(..) => RDF_LANG_STRING.as_ref(),
         }
     }
 
     /// The [language tag](https://www.w3.org/TR/rdf11-concepts/#dfn-language-tag) of this literal, if any
     pub fn get_language_tag(&self) -> Option<LanguageTag<&str>> {
         match self {
-            GenericLiteral::Typed(..) => None,
-            GenericLiteral::LanguageString(_, tag) => Some(tag.as_ref()),
+            Self::Typed(..) => None,
+            Self::LanguageString(_, tag) => Some(tag.as_ref()),
         }
     }
 }
@@ -81,14 +81,14 @@ impl<T: Borrow<str> + for<'x> From<&'x str>> TryFromTerm for GenericLiteral<T> {
             let lex = unsafe { term.lexical_form().unwrap_unchecked() };
             let lex = T::from(&lex);
             if let Some(tag) = term.language_tag() {
-                Ok(GenericLiteral::LanguageString(
+                Ok(Self::LanguageString(
                     lex,
                     tag.map_unchecked(|txt| T::from(&txt)),
                 ))
             } else {
                 // the following is safe because we checked term.kind()
                 let dt = unsafe { term.datatype().unwrap_unchecked() };
-                Ok(GenericLiteral::Typed(
+                Ok(Self::Typed(
                     lex,
                     dt.map_unchecked(|txt| T::from(&txt)),
                 ))
@@ -109,7 +109,7 @@ impl<T: Borrow<str> + Debug> Eq for GenericLiteral<T> {}
 
 impl<T: Borrow<str> + Debug> std::hash::Hash for GenericLiteral<T> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        Term::hash(self, state)
+        Term::hash(self, state);
     }
 }
 
@@ -170,6 +170,6 @@ mod test {
 
     #[test]
     fn generic_literal_from_iri_errs() {
-        assert!(GenericLiteral::<String>::try_from_term(rdf::type_).is_err())
+        assert!(GenericLiteral::<String>::try_from_term(rdf::type_).is_err());
     }
 }

--- a/term/src/_generic.rs
+++ b/term/src/_generic.rs
@@ -88,10 +88,7 @@ impl<T: Borrow<str> + for<'x> From<&'x str>> TryFromTerm for GenericLiteral<T> {
             } else {
                 // the following is safe because we checked term.kind()
                 let dt = unsafe { term.datatype().unwrap_unchecked() };
-                Ok(Self::Typed(
-                    lex,
-                    dt.map_unchecked(|txt| T::from(&txt)),
-                ))
+                Ok(Self::Typed(lex, dt.map_unchecked(|txt| T::from(&txt))))
             }
         } else {
             Err(GenericLiteralError(term.kind()))

--- a/term/src/_macro.rs
+++ b/term/src/_macro.rs
@@ -330,12 +330,14 @@ macro_rules! gen_stash {
 
             impl $type_name {
                 /// Create a new empty stash
-                #[must_use] pub fn new() -> Self {
+                #[must_use]
+                pub fn new() -> Self {
                     Default::default()
                 }
 
                 /// Retrieve a value from the stash, if present
-                #[must_use] pub fn get(&self, probe: &str) -> Option<&W<str>> {
+                #[must_use]
+                pub fn get(&self, probe: &str) -> Option<&W<str>> {
                     self.store.get(probe)
                 }
 
@@ -352,12 +354,14 @@ macro_rules! gen_stash {
                 }
 
                 /// How many values are stored in this stash
-                #[must_use] pub fn len(&self) -> usize {
+                #[must_use]
+                pub fn len(&self) -> usize {
                     self.store.len()
                 }
 
                 /// Is this stash empty?
-                #[must_use] pub fn is_empty(&self) -> bool {
+                #[must_use]
+                pub fn is_empty(&self) -> bool {
                     self.store.is_empty()
                 }
             }

--- a/term/src/_macro.rs
+++ b/term/src/_macro.rs
@@ -330,12 +330,12 @@ macro_rules! gen_stash {
 
             impl $type_name {
                 /// Create a new empty stash
-                pub fn new() -> Self {
+                #[must_use] pub fn new() -> Self {
                     Default::default()
                 }
 
                 /// Retrieve a value from the stash, if present
-                pub fn get(&self, probe: &str) -> Option<&W<str>> {
+                #[must_use] pub fn get(&self, probe: &str) -> Option<&W<str>> {
                     self.store.get(probe)
                 }
 
@@ -352,12 +352,12 @@ macro_rules! gen_stash {
                 }
 
                 /// How many values are stored in this stash
-                pub fn len(&self) -> usize {
+                #[must_use] pub fn len(&self) -> usize {
                     self.store.len()
                 }
 
                 /// Is this stash empty?
-                pub fn is_empty(&self) -> bool {
+                #[must_use] pub fn is_empty(&self) -> bool {
                     self.store.is_empty()
                 }
             }

--- a/turtle/src/parser/gnq.rs
+++ b/turtle/src/parser/gnq.rs
@@ -3,7 +3,7 @@
 //! [N-Quads]: https://www.w3.org/TR/n-quads/
 use rio_turtle::GeneralizedNQuadsParser as RioGNQParser;
 use sophia_api::parser::QuadParser;
-use sophia_rio::parser::*;
+use sophia_rio::parser::GeneralizedRioSource;
 use std::io::BufRead;
 
 /// N-Quads parser based on RIO.

--- a/turtle/src/parser/gtrig.rs
+++ b/turtle/src/parser/gtrig.rs
@@ -1,12 +1,12 @@
-//! Adapter for the Generalized TriG parser from [RIO](https://github.com/Tpt/rio/blob/master/turtle/src/gtrig.rs)
+//! Adapter for the Generalized `TriG` parser from [RIO](https://github.com/Tpt/rio/blob/master/turtle/src/gtrig.rs)
 
 use rio_turtle::GTriGParser as RioGTriGParser;
 use sophia_api::parser::QuadParser;
 use sophia_iri::Iri;
-use sophia_rio::parser::*;
+use sophia_rio::parser::GeneralizedRioSource;
 use std::io::BufRead;
 
-/// TriG parser based on RIO.
+/// `TriG` parser based on RIO.
 #[derive(Clone, Debug, Default)]
 pub struct GTriGParser {
     /// The base IRI used by this parser to resolve relative IRI-references.
@@ -47,7 +47,7 @@ mod test {
 
     #[test]
     fn test_simple_gtrig_string() -> std::result::Result<(), Box<dyn std::error::Error>> {
-        let gtrig = r#"
+        let gtrig = r"
             @prefix : <http://example.org/ns/> .
 
             <#me> :knows _:alice {|
@@ -56,7 +56,7 @@ mod test {
             <tag:g1> {
                 _:alice a :Person ; :name ?name.
             }
-        "#;
+        ";
 
         let mut d = MyDataset::new();
         let p = GTriGParser {

--- a/turtle/src/parser/nq.rs
+++ b/turtle/src/parser/nq.rs
@@ -3,7 +3,7 @@
 //! [N-Quads]: https://www.w3.org/TR/n-quads/
 use rio_turtle::NQuadsParser as RioNQParser;
 use sophia_api::parser::QuadParser;
-use sophia_rio::parser::*;
+use sophia_rio::parser::StrictRioQuadSource;
 use std::io::BufRead;
 
 /// N-Quads parser based on RIO.

--- a/turtle/src/parser/nt.rs
+++ b/turtle/src/parser/nt.rs
@@ -3,7 +3,7 @@
 //! [N-Triples]: https://www.w3.org/TR/n-triples/
 use rio_turtle::NTriplesParser as RioNTParser;
 use sophia_api::parser::TripleParser;
-use sophia_rio::parser::*;
+use sophia_rio::parser::StrictRioTripleSource;
 use std::io::BufRead;
 
 /// N-Triples parser based on RIO.

--- a/turtle/src/parser/trig.rs
+++ b/turtle/src/parser/trig.rs
@@ -1,12 +1,12 @@
-//! Adapter for the TriG parser from [RIO](https://github.com/Tpt/rio/blob/master/turtle/src/turtle.rs)
+//! Adapter for the `TriG` parser from [RIO](https://github.com/Tpt/rio/blob/master/turtle/src/turtle.rs)
 
 use rio_turtle::TriGParser as RioTriGParser;
 use sophia_api::parser::QuadParser;
 use sophia_iri::Iri;
-use sophia_rio::parser::*;
+use sophia_rio::parser::StrictRioQuadSource;
 use std::io::BufRead;
 
-/// TriG parser based on RIO.
+/// `TriG` parser based on RIO.
 #[derive(Clone, Debug, Default)]
 pub struct TriGParser {
     /// The base IRI used by this parser to resolve relative IRI-references.

--- a/turtle/src/parser/turtle.rs
+++ b/turtle/src/parser/turtle.rs
@@ -2,7 +2,7 @@
 use rio_turtle::TurtleParser as RioTurtleParser;
 use sophia_api::parser::TripleParser;
 use sophia_iri::Iri;
-use sophia_rio::parser::*;
+use sophia_rio::parser::StrictRioTripleSource;
 use std::io::BufRead;
 
 /// Turtle parser based on RIO.

--- a/turtle/src/serializer/_pretty.rs
+++ b/turtle/src/serializer/_pretty.rs
@@ -1,9 +1,9 @@
-//! Utility code for pretty-printing Turtle and TriG.
+//! Utility code for pretty-printing Turtle and `TriG`.
 //!
 //! Possible improvements:
-//! 1. PrettifiableDataset should encapsulate some of the "indexes" built by Prettifier
-//!    (labelled, subject_types, named_graphs)
-//!    and build directly in CollectibleDataset::from_quad_source().
+//! 1. `PrettifiableDataset` should encapsulate some of the "indexes" built by Prettifier
+//!    (labelled, `subject_types`, `named_graphs`)
+//!    and build directly in `CollectibleDataset::from_quad_source()`.
 //!
 //! 2. Instead of writing directly to the output,
 //!    generate a hierarchical structure,
@@ -29,10 +29,10 @@ use std::ops::Range;
 
 pub type PrettifiableDataset<'a> = BTreeSet<Gspo<SimpleTerm<'a>>>;
 
-/// Serialize `dataset` in pretty TriG on `write`, using the given `config`.
+/// Serialize `dataset` in pretty `TriG` on `write`, using the given `config`.
 ///
 /// NB: if dataset only contains a default graph,
-/// the resulting TriG will be valid Turtle.
+/// the resulting `TriG` will be valid Turtle.
 pub fn prettify<W>(
     dataset: PrettifiableDataset<'_>,
     mut write: W,
@@ -51,7 +51,7 @@ where
     Ok(())
 }
 
-/// write the prefix declarations of the given prefix_map, using SPARQL style.
+/// write the prefix declarations of the given `prefix_map`, using SPARQL style.
 fn write_prefixes<W, P>(mut write: W, prefix_map: &P) -> io::Result<()>
 where
     W: io::Write,
@@ -271,7 +271,7 @@ impl<'a, W: Write> Prettifier<'a, W> {
     }
 
     fn write_term(&mut self, term: &'a SimpleTerm<'a>) -> io::Result<()> {
-        use TermKind::*;
+        use TermKind::{BlankNode, Iri, Literal, Triple, Variable};
         match term.kind() {
             Iri => self.write_iri(&term.iri().unwrap()),
             BlankNode => self.write_bnode(term),
@@ -414,7 +414,7 @@ impl<'a, W: Write> Prettifier<'a, W> {
 /// blank nodes MUST be labelled (as opposed to described with square brackets) if
 /// - they are used in several named graphs, or
 /// - they are used several times as object, or
-/// - they are used as predicate or graph_name, or
+/// - they are used as predicate or `graph_name`, or
 /// - they are used in a quoted triple, or
 /// - they are involved in a blank node cycle.
 ///
@@ -474,7 +474,7 @@ fn build_labelled<'a>(d: &'a PrettifiableDataset) -> BTreeSet<&'a SimpleTerm<'a>
         }
     }
     // detect blank node cycles
-    let keys: Vec<_> = profiles.keys().cloned().collect();
+    let keys: Vec<_> = profiles.keys().copied().collect();
     for key in keys {
         let profile = profiles.get_mut(&key).unwrap();
         if profile.bad || profile.visited {
@@ -544,7 +544,7 @@ fn build_subject_types<'a>(
         .map(|q| (q.g(), q.s()))
         .dedup()
         .map(|(g, s)| {
-            use TermKind::*;
+            use TermKind::{BlankNode, Triple};
             let st = match s.kind() {
                 BlankNode => {
                     if !labelled.contains(&s)
@@ -746,7 +746,7 @@ where
 // ---------------------------------------------------------------------------------
 
 #[cfg(test)]
-pub(crate) mod test {
+pub mod test {
     use super::*;
 
     #[test]

--- a/turtle/src/serializer/nq.rs
+++ b/turtle/src/serializer/nq.rs
@@ -85,12 +85,14 @@ where
 impl NqSerializer<Vec<u8>> {
     /// Create a new serializer which targets a `String`.
     #[inline]
-    #[must_use] pub fn new_stringifier() -> Self {
+    #[must_use]
+    pub fn new_stringifier() -> Self {
         Self::new(Vec::new())
     }
     /// Create a new serializer which targets a `String` with a custom config.
     #[inline]
-    #[must_use] pub const fn new_stringifier_with_config(config: NqConfig) -> Self {
+    #[must_use]
+    pub const fn new_stringifier_with_config(config: NqConfig) -> Self {
         Self::new_with_config(Vec::new(), config)
     }
 }

--- a/turtle/src/serializer/nq.rs
+++ b/turtle/src/serializer/nq.rs
@@ -11,7 +11,7 @@
 
 use super::nt::{write_term, write_triple};
 use sophia_api::quad::Quad;
-use sophia_api::serializer::*;
+use sophia_api::serializer::{QuadSerializer, Stringifier};
 use sophia_api::source::{QuadSource, StreamResult};
 use std::io;
 
@@ -30,17 +30,17 @@ where
 {
     /// Build a new N-Quads serializer writing to `write`, with the default config.
     #[inline]
-    pub fn new(write: W) -> NqSerializer<W> {
+    pub fn new(write: W) -> Self {
         Self::new_with_config(write, NqConfig::default())
     }
 
     /// Build a new N-Quads serializer writing to `write`, with the given config.
-    pub fn new_with_config(write: W, config: NqConfig) -> NqSerializer<W> {
-        NqSerializer { config, write }
+    pub const fn new_with_config(write: W, config: NqConfig) -> Self {
+        Self { config, write }
     }
 
     /// Borrow this serializer's configuration.
-    pub fn config(&self) -> &NqConfig {
+    pub const fn config(&self) -> &NqConfig {
         &self.config
     }
 }
@@ -78,20 +78,20 @@ where
                 }
                 .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
             })
-            .map(|_| self)
+            .map(|()| self)
     }
 }
 
 impl NqSerializer<Vec<u8>> {
     /// Create a new serializer which targets a `String`.
     #[inline]
-    pub fn new_stringifier() -> Self {
-        NqSerializer::new(Vec::new())
+    #[must_use] pub fn new_stringifier() -> Self {
+        Self::new(Vec::new())
     }
     /// Create a new serializer which targets a `String` with a custom config.
     #[inline]
-    pub fn new_stringifier_with_config(config: NqConfig) -> Self {
-        NqSerializer::new_with_config(Vec::new(), config)
+    #[must_use] pub const fn new_stringifier_with_config(config: NqConfig) -> Self {
+        Self::new_with_config(Vec::new(), config)
     }
 }
 

--- a/turtle/src/serializer/nt.rs
+++ b/turtle/src/serializer/nt.rs
@@ -89,12 +89,14 @@ where
 impl NtSerializer<Vec<u8>> {
     /// Create a new serializer which targets a `String`.
     #[inline]
-    #[must_use] pub fn new_stringifier() -> Self {
+    #[must_use]
+    pub fn new_stringifier() -> Self {
         Self::new(Vec::new())
     }
     /// Create a new serializer which targets a `String` with a custom config.
     #[inline]
-    #[must_use] pub const fn new_stringifier_with_config(config: NtConfig) -> Self {
+    #[must_use]
+    pub const fn new_stringifier_with_config(config: NtConfig) -> Self {
         Self::new_with_config(Vec::new(), config)
     }
 }

--- a/turtle/src/serializer/trig.rs
+++ b/turtle/src/serializer/trig.rs
@@ -84,12 +84,14 @@ where
 impl TrigSerializer<Vec<u8>> {
     /// Create a new serializer which targets a `String`.
     #[inline]
-    #[must_use] pub fn new_stringifier() -> Self {
+    #[must_use]
+    pub fn new_stringifier() -> Self {
         Self::new(Vec::new())
     }
     /// Create a new serializer which targets a `String` with a custom config.
     #[inline]
-    #[must_use] pub const fn new_stringifier_with_config(config: TrigConfig) -> Self {
+    #[must_use]
+    pub const fn new_stringifier_with_config(config: TrigConfig) -> Self {
         Self::new_with_config(Vec::new(), config)
     }
 }

--- a/turtle/src/serializer/turtle.rs
+++ b/turtle/src/serializer/turtle.rs
@@ -39,7 +39,8 @@ impl TurtleConfig {
     /// If true, extra effort will be made to group related triples together,
     /// and to use the collection syntax whenever possible.
     /// This requires storing the whole graph in memory.
-    #[must_use] pub const fn pretty(&self) -> bool {
+    #[must_use]
+    pub const fn pretty(&self) -> bool {
         self.pretty
     }
 
@@ -47,7 +48,8 @@ impl TurtleConfig {
     /// (defaults to a map containing rdf:, rdfs: and xsd:)
     ///
     /// NB: currently, only used if [`pretty`][`TurtleConfig::pretty`] is `true`.
-    #[must_use] pub fn prefix_map(&self) -> &[PrefixMapPair] {
+    #[must_use]
+    pub fn prefix_map(&self) -> &[PrefixMapPair] {
         &self.prefix_map
     }
 
@@ -55,12 +57,14 @@ impl TurtleConfig {
     /// (defaults to `"  "`, can only contain ASCII whitespaces)
     ///
     /// NB: currently, only used if [`pretty`][`TurtleConfig::pretty`] is `true`.
-    #[must_use] pub fn indentation(&self) -> &str {
+    #[must_use]
+    pub fn indentation(&self) -> &str {
         &self.indentation
     }
 
     /// Build a new default [`TurtleConfig`].
-    #[must_use] pub fn new() -> Self {
+    #[must_use]
+    pub fn new() -> Self {
         let pretty = false;
         let prefix_map = Self::default_prefix_map();
         let indentation = "  ".to_string();
@@ -72,7 +76,8 @@ impl TurtleConfig {
     }
 
     /// Transform a [`TurtleConfig`] by setting the [`pretty`][`TurtleConfig::pretty`] flag.
-    #[must_use] pub const fn with_pretty(mut self, b: bool) -> Self {
+    #[must_use]
+    pub const fn with_pretty(mut self, b: bool) -> Self {
         self.pretty = b;
         self
     }
@@ -84,7 +89,8 @@ impl TurtleConfig {
     }
 
     /// Transform a [`TurtleConfig`] by setting the [`prefix_map`][`TurtleConfig::prefix_map`] flag.
-    #[must_use] pub fn with_own_prefix_map(mut self, pm: Vec<PrefixMapPair>) -> Self {
+    #[must_use]
+    pub fn with_own_prefix_map(mut self, pm: Vec<PrefixMapPair>) -> Self {
         self.prefix_map = pm;
         self
     }
@@ -101,7 +107,8 @@ impl TurtleConfig {
     }
 
     /// Return the prefix map that is used when none is provided
-    #[must_use] pub fn default_prefix_map() -> Vec<PrefixMapPair> {
+    #[must_use]
+    pub fn default_prefix_map() -> Vec<PrefixMapPair> {
         vec![
             (
                 Prefix::new_unchecked("rdf".into()),
@@ -187,12 +194,14 @@ where
 impl TurtleSerializer<Vec<u8>> {
     /// Create a new serializer which targets a `String`.
     #[inline]
-    #[must_use] pub fn new_stringifier() -> Self {
+    #[must_use]
+    pub fn new_stringifier() -> Self {
         Self::new(Vec::new())
     }
     /// Create a new serializer which targets a `String` with a custom config.
     #[inline]
-    #[must_use] pub const fn new_stringifier_with_config(config: TurtleConfig) -> Self {
+    #[must_use]
+    pub const fn new_stringifier_with_config(config: TurtleConfig) -> Self {
         Self::new_with_config(Vec::new(), config)
     }
 }

--- a/xml/src/parser.rs
+++ b/xml/src/parser.rs
@@ -6,7 +6,7 @@
 use rio_xml::RdfXmlParser as RioRdfXmlParser;
 use sophia_api::parser::TripleParser;
 use sophia_iri::Iri;
-use sophia_rio::parser::*;
+use sophia_rio::parser::StrictRioTripleSource;
 use std::io::BufRead;
 
 /// N-Triples parser based on RIO.

--- a/xml/src/serializer.rs
+++ b/xml/src/serializer.rs
@@ -25,17 +25,17 @@ pub struct RdfXmlConfig {
 impl RdfXmlConfig {
     /// Size of the indentation to use in the serialization.
     /// (defaults to 0, meaning no indentation nor linebreaks)
-    pub fn indentation(&self) -> usize {
+    #[must_use] pub const fn indentation(&self) -> usize {
         self.indentation
     }
 
     /// Build a new default [`RdfXmlConfig`]
-    pub fn new() -> Self {
+    #[must_use] pub fn new() -> Self {
         Default::default()
     }
 
     /// Transform an [`RdfXmlConfig`] by setting the [`indentation`](RdfXmlConfig::indentation).
-    pub fn with_indentation(mut self, i: usize) -> Self {
+    #[must_use] pub const fn with_indentation(mut self, i: usize) -> Self {
         self.indentation = i;
         self
     }
@@ -53,17 +53,17 @@ where
 {
     /// Build a new N-Triples serializer writing to `write`, with the default config.
     #[inline]
-    pub fn new(write: W) -> RdfXmlSerializer<W> {
+    pub fn new(write: W) -> Self {
         Self::new_with_config(write, RdfXmlConfig::default())
     }
 
     /// Build a new N-Triples serializer writing to `write`, with the given config.
-    pub fn new_with_config(write: W, config: RdfXmlConfig) -> RdfXmlSerializer<W> {
-        RdfXmlSerializer { config, write }
+    pub const fn new_with_config(write: W, config: RdfXmlConfig) -> Self {
+        Self { config, write }
     }
 
     /// Borrow this serializer's configuration.
-    pub fn config(&self) -> &RdfXmlConfig {
+    pub const fn config(&self) -> &RdfXmlConfig {
         &self.config
     }
 }
@@ -97,13 +97,13 @@ where
 impl RdfXmlSerializer<Vec<u8>> {
     /// Create a new serializer which targets a `String`.
     #[inline]
-    pub fn new_stringifier() -> Self {
-        RdfXmlSerializer::new(Vec::new())
+    #[must_use] pub fn new_stringifier() -> Self {
+        Self::new(Vec::new())
     }
     /// Create a new serializer which targets a `String` with a custom config.
     #[inline]
-    pub fn new_stringifier_with_config(config: RdfXmlConfig) -> Self {
-        RdfXmlSerializer::new_with_config(Vec::new(), config)
+    #[must_use] pub const fn new_stringifier_with_config(config: RdfXmlConfig) -> Self {
+        Self::new_with_config(Vec::new(), config)
     }
 }
 
@@ -140,7 +140,7 @@ pub(crate) mod test {
     #[test]
     fn roundtrip() -> Result<(), Box<dyn std::error::Error>> {
         for rdfxml in TESTS {
-            println!("==========\n{}\n----------", rdfxml);
+            println!("==========\n{rdfxml}\n----------");
             let g1: Vec<[SimpleTerm; 3]> = crate::parser::parse_str(rdfxml).collect_triples()?;
 
             let out = RdfXmlSerializer::new_stringifier()
@@ -159,7 +159,7 @@ pub(crate) mod test {
     fn roundtrip_with_ident() -> Result<(), Box<dyn std::error::Error>> {
         let config = RdfXmlConfig::new().with_indentation(4);
         for rdfxml in TESTS {
-            println!("==========\n{}\n----------", rdfxml);
+            println!("==========\n{rdfxml}\n----------");
             let g1: Vec<[SimpleTerm; 3]> = crate::parser::parse_str(rdfxml).collect_triples()?;
 
             let out = RdfXmlSerializer::new_stringifier_with_config(config.clone())

--- a/xml/src/serializer.rs
+++ b/xml/src/serializer.rs
@@ -25,17 +25,20 @@ pub struct RdfXmlConfig {
 impl RdfXmlConfig {
     /// Size of the indentation to use in the serialization.
     /// (defaults to 0, meaning no indentation nor linebreaks)
-    #[must_use] pub const fn indentation(&self) -> usize {
+    #[must_use]
+    pub const fn indentation(&self) -> usize {
         self.indentation
     }
 
     /// Build a new default [`RdfXmlConfig`]
-    #[must_use] pub fn new() -> Self {
+    #[must_use]
+    pub fn new() -> Self {
         Default::default()
     }
 
     /// Transform an [`RdfXmlConfig`] by setting the [`indentation`](RdfXmlConfig::indentation).
-    #[must_use] pub const fn with_indentation(mut self, i: usize) -> Self {
+    #[must_use]
+    pub const fn with_indentation(mut self, i: usize) -> Self {
         self.indentation = i;
         self
     }
@@ -97,12 +100,14 @@ where
 impl RdfXmlSerializer<Vec<u8>> {
     /// Create a new serializer which targets a `String`.
     #[inline]
-    #[must_use] pub fn new_stringifier() -> Self {
+    #[must_use]
+    pub fn new_stringifier() -> Self {
         Self::new(Vec::new())
     }
     /// Create a new serializer which targets a `String` with a custom config.
     #[inline]
-    #[must_use] pub const fn new_stringifier_with_config(config: RdfXmlConfig) -> Self {
+    #[must_use]
+    pub const fn new_stringifier_with_config(config: RdfXmlConfig) -> Self {
         Self::new_with_config(Vec::new(), config)
     }
 }

--- a/xml/src/serializer.rs
+++ b/xml/src/serializer.rs
@@ -33,7 +33,7 @@ impl RdfXmlConfig {
     /// Build a new default [`RdfXmlConfig`]
     #[must_use]
     pub fn new() -> Self {
-        Default::default()
+        Self::default()
     }
 
     /// Transform an [`RdfXmlConfig`] by setting the [`indentation`](RdfXmlConfig::indentation).


### PR DESCRIPTION
Ran `cargo clippy --fix --all-targets --all-features -- -W clippy::uninlined_format_args -W clippy::pedantic -W clippy::nursery` to apply some non default clippy fixes automatically.

* Added `.clippy.toml` to the workspace
* Added clippy lint sectio to the workspace `Cargo.toml`