### PR TITLE
reorder CI steps

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -7,27 +7,27 @@ jobs:
     name: fmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
       - run: rustup update
       - run: rustup component add rustfmt
+      - uses: actions/checkout@v4
       - run: cargo fmt -- --check
 
   clippy:
     name: clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
       - run: rustup update
       - run: rustup component add clippy
+      - uses: actions/checkout@v4
       - run: cargo clippy --all --all-targets --all-features
 
   test:
     runs-on: ubuntu-latest
     steps:
+      - run: rustup update
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - run: rustup update
       - run: cargo build --all-features
       - run: cargo test --verbose --all --all-features
         env:
@@ -36,5 +36,5 @@ jobs:
   typos:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
       - uses: crate-ci/typos@master
+      - uses: actions/checkout@v4

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -36,5 +36,5 @@ jobs:
   typos:
     runs-on: ubuntu-latest
     steps:
-      - uses: crate-ci/typos@master
       - uses: actions/checkout@v4
+      - uses: crate-ci/typos@master

--- a/typos.toml
+++ b/typos.toml
@@ -3,6 +3,8 @@ extend-ignore-identifiers-re = [
   # appear in several grammars
   "PN_[A-Z_]+",
   "pn_local",
+  # I prefer this to 'type_'
+  "typ",
 ]
 extend-ignore-re = [
   "raison d'être",


### PR DESCRIPTION
I don't know if GH actions cache intermediate states of their container, but if they do, it is probably beneficial to invoke rustup *before* checking out the repo.