### PR TITLE
Fix typo: "RFC 3687" -> "RFC 3987"

### DIFF
--- a/iri/src/_wrapper.rs
+++ b/iri/src/_wrapper.rs
@@ -7,7 +7,7 @@ use std::fmt::Display;
 
 wrap! { Iri borrowing str :
     /// This wrapper guarantees that the underlying `str`
-    /// satisfies the `IRI` rule in  RFC-3687
+    /// satisfies the `IRI` rule in  RFC-3987
     /// (i.e. an absolute IRI with an optional fragment).
     pub fn new(iri: T) -> Result<Self, InvalidIri> {
         if is_absolute_iri_ref(iri.borrow()) {
@@ -55,7 +55,7 @@ impl<T: Borrow<str>> Display for Iri<T> {
 
 wrap! { IriRef borrowing str :
     /// This wrapper guarantees that the underlying `str`
-    /// satisfies the `irelative-ref` rule in  RFC-3687
+    /// satisfies the `irelative-ref` rule in  RFC-3987
     /// (i.e. an absolute or relative IRI reference).
     pub fn new(iri: T) -> Result<Self, InvalidIri> {
         if is_valid_iri_ref(iri.borrow()) {


### PR DESCRIPTION
The correct RFC number is [3987](https://datatracker.ietf.org/doc/html/rfc3987#section-2.2), **Internationalized Resource Identifiers (IRIs)**, not [3687](https://datatracker.ietf.org/doc/html/rfc3687), **Lightweight Directory Access Protocol (LDAP) and X.500 Component Matching Rules**.