### PR TITLE
Relax lifetimes of matched triples and quads

### DIFF
--- a/api/src/dataset.rs
+++ b/api/src/dataset.rs
@@ -161,18 +161,19 @@ pub trait Dataset {
     /// #
     /// # Ok(()) }
     /// ```
-    fn quads_matching<'s, S, P, O, G>(
+    fn quads_matching<'s, 't, S, P, O, G>(
         &'s self,
         sm: S,
         pm: P,
         om: O,
         gm: G,
-    ) -> impl Iterator<Item = DResult<Self, Self::Quad<'s>>> + 's
+    ) -> impl Iterator<Item = DResult<Self, Self::Quad<'s>>> + 't
     where
-        S: TermMatcher + 's,
-        P: TermMatcher + 's,
-        O: TermMatcher + 's,
-        G: GraphNameMatcher + 's,
+        's: 't,
+        S: TermMatcher + 't,
+        P: TermMatcher + 't,
+        O: TermMatcher + 't,
+        G: GraphNameMatcher + 't,
     {
         self.quads().filter_ok(move |q| {
             q.matched_by(

--- a/api/src/dataset/_foreign_impl.rs
+++ b/api/src/dataset/_foreign_impl.rs
@@ -24,18 +24,19 @@ impl<T: Dataset + ?Sized> Dataset for &T {
         T::quads(*self)
     }
 
-    fn quads_matching<'s, S, P, O, G>(
+    fn quads_matching<'s, 't, S, P, O, G>(
         &'s self,
         sm: S,
         pm: P,
         om: O,
         gm: G,
-    ) -> impl Iterator<Item = DResult<Self, Self::Quad<'s>>> + 's
+    ) -> impl Iterator<Item = DResult<Self, Self::Quad<'s>>> + 't
     where
-        S: TermMatcher + 's,
-        P: TermMatcher + 's,
-        O: TermMatcher + 's,
-        G: GraphNameMatcher + 's,
+        's: 't,
+        S: TermMatcher + 't,
+        P: TermMatcher + 't,
+        O: TermMatcher + 't,
+        G: GraphNameMatcher + 't,
     {
         T::quads_matching(*self, sm, pm, om, gm)
     }
@@ -103,18 +104,19 @@ impl<T: Dataset + ?Sized> Dataset for &mut T {
         T::quads(*self)
     }
 
-    fn quads_matching<'s, S, P, O, G>(
+    fn quads_matching<'s, 't, S, P, O, G>(
         &'s self,
         sm: S,
         pm: P,
         om: O,
         gm: G,
-    ) -> impl Iterator<Item = DResult<Self, Self::Quad<'s>>> + 's
+    ) -> impl Iterator<Item = DResult<Self, Self::Quad<'s>>> + 't
     where
-        S: TermMatcher + 's,
-        P: TermMatcher + 's,
-        O: TermMatcher + 's,
-        G: GraphNameMatcher + 's,
+        's: 't,
+        S: TermMatcher + 't,
+        P: TermMatcher + 't,
+        O: TermMatcher + 't,
+        G: GraphNameMatcher + 't,
     {
         T::quads_matching(*self, sm, pm, om, gm)
     }

--- a/api/src/dataset/adapter.rs
+++ b/api/src/dataset/adapter.rs
@@ -44,18 +44,19 @@ where
     }
 
     #[allow(refining_impl_trait)]
-    fn quads_matching<'s, S, P, O, G>(
+    fn quads_matching<'s, 't, S, P, O, G>(
         &'s self,
         sm: S,
         pm: P,
         om: O,
         gm: G,
-    ) -> Box<dyn Iterator<Item = DResult<Self, Self::Quad<'s>>> + 's>
+    ) -> Box<dyn Iterator<Item = DResult<Self, Self::Quad<'s>>> + 't>
     where
-        S: TermMatcher + 's,
-        P: TermMatcher + 's,
-        O: TermMatcher + 's,
-        G: GraphNameMatcher + 's,
+        's: 't,
+        S: TermMatcher + 't,
+        P: TermMatcher + 't,
+        O: TermMatcher + 't,
+        G: GraphNameMatcher + 't,
     {
         if gm.matches(None as GraphName<&GTerm<T>>) {
             Box::new(

--- a/api/src/graph.rs
+++ b/api/src/graph.rs
@@ -154,16 +154,17 @@ pub trait Graph {
     /// #
     /// # Ok(()) }
     /// ```
-    fn triples_matching<'s, S, P, O>(
+    fn triples_matching<'s, 't, S, P, O>(
         &'s self,
         sm: S,
         pm: P,
         om: O,
-    ) -> impl Iterator<Item = GResult<Self, Self::Triple<'s>>> + 's
+    ) -> impl Iterator<Item = GResult<Self, Self::Triple<'s>>> + 't
     where
-        S: TermMatcher + 's,
-        P: TermMatcher + 's,
-        O: TermMatcher + 's,
+        's: 't,
+        S: TermMatcher + 't,
+        P: TermMatcher + 't,
+        O: TermMatcher + 't,
     {
         self.triples()
             .filter_ok(move |t| t.matched_by(sm.matcher_ref(), pm.matcher_ref(), om.matcher_ref()))

--- a/api/src/graph/_foreign_impl.rs
+++ b/api/src/graph/_foreign_impl.rs
@@ -24,16 +24,17 @@ impl<T: Graph + ?Sized> Graph for &T {
         T::triples(*self)
     }
 
-    fn triples_matching<'s, S, P, O>(
+    fn triples_matching<'s, 't, S, P, O>(
         &'s self,
         sm: S,
         pm: P,
         om: O,
-    ) -> impl Iterator<Item = GResult<Self, Self::Triple<'s>>> + 's
+    ) -> impl Iterator<Item = GResult<Self, Self::Triple<'s>>> + 't
     where
-        S: TermMatcher + 's,
-        P: TermMatcher + 's,
-        O: TermMatcher + 's,
+        's: 't,
+        S: TermMatcher + 't,
+        P: TermMatcher + 't,
+        O: TermMatcher + 't,
     {
         T::triples_matching(*self, sm, pm, om)
     }
@@ -96,16 +97,17 @@ impl<T: Graph + ?Sized> Graph for &mut T {
         T::triples(*self)
     }
 
-    fn triples_matching<'s, S, P, O>(
+    fn triples_matching<'s, 't, S, P, O>(
         &'s self,
         sm: S,
         pm: P,
         om: O,
-    ) -> impl Iterator<Item = GResult<Self, Self::Triple<'s>>> + 's
+    ) -> impl Iterator<Item = GResult<Self, Self::Triple<'s>>> + 't
     where
-        S: TermMatcher + 's,
-        P: TermMatcher + 's,
-        O: TermMatcher + 's,
+        's: 't,
+        S: TermMatcher + 't,
+        P: TermMatcher + 't,
+        O: TermMatcher + 't,
     {
         T::triples_matching(*self, sm, pm, om)
     }

--- a/api/src/graph/adapter.rs
+++ b/api/src/graph/adapter.rs
@@ -40,16 +40,17 @@ impl<T: Dataset> Graph for UnionGraph<T> {
             .map(|r| r.map(Quad::into_triple))
     }
 
-    fn triples_matching<'s, S, P, O>(
+    fn triples_matching<'s, 't, S, P, O>(
         &'s self,
         sm: S,
         pm: P,
         om: O,
-    ) -> impl Iterator<Item = GResult<Self, Self::Triple<'s>>> + 's
+    ) -> impl Iterator<Item = GResult<Self, Self::Triple<'s>>> + 't
     where
-        S: TermMatcher + 's,
-        P: TermMatcher + 's,
-        O: TermMatcher + 's,
+        's: 't,
+        S: TermMatcher + 't,
+        P: TermMatcher + 't,
+        O: TermMatcher + 't,
     {
         self.0
             .quads_matching(sm, pm, om, Any)
@@ -131,16 +132,17 @@ impl<D: Dataset, M: GraphNameMatcher + Copy> Graph for PartialUnionGraph<D, M> {
             .map(|r| r.map(Quad::into_triple))
     }
 
-    fn triples_matching<'s, S, P, O>(
+    fn triples_matching<'s, 't, S, P, O>(
         &'s self,
         sm: S,
         pm: P,
         om: O,
-    ) -> impl Iterator<Item = GResult<Self, Self::Triple<'s>>> + 's
+    ) -> impl Iterator<Item = GResult<Self, Self::Triple<'s>>> + 't
     where
-        S: TermMatcher + 's,
-        P: TermMatcher + 's,
-        O: TermMatcher + 's,
+        's: 't,
+        S: TermMatcher + 't,
+        P: TermMatcher + 't,
+        O: TermMatcher + 't,
     {
         self.d
             .quads_matching(sm, pm, om, self.m)
@@ -199,16 +201,17 @@ impl<D: Dataset, G: Term> Graph for DatasetGraph<D, G> {
             .map(|r| r.map(Quad::into_triple))
     }
 
-    fn triples_matching<'s, S, P, O>(
+    fn triples_matching<'s, 't, S, P, O>(
         &'s self,
         sm: S,
         pm: P,
         om: O,
-    ) -> impl Iterator<Item = GResult<Self, Self::Triple<'s>>> + 's
+    ) -> impl Iterator<Item = GResult<Self, Self::Triple<'s>>> + 't
     where
-        S: TermMatcher + 's,
-        P: TermMatcher + 's,
-        O: TermMatcher + 's,
+        's: 't,
+        S: TermMatcher + 't,
+        P: TermMatcher + 't,
+        O: TermMatcher + 't,
     {
         self.d
             .quads_matching(sm, pm, om, [self.g()])

--- a/inmem/src/dataset.rs
+++ b/inmem/src/dataset.rs
@@ -47,18 +47,19 @@ impl<TI: GraphNameIndex> Dataset for GenericLightDataset<TI> {
     }
 
     #[allow(refining_impl_trait)]
-    fn quads_matching<'s, S, P, O, G>(
+    fn quads_matching<'s, 't, S, P, O, G>(
         &'s self,
         sm: S,
         pm: P,
         om: O,
         gm: G,
-    ) -> Box<dyn Iterator<Item = DResult<Self, Self::Quad<'s>>> + 's>
+    ) -> Box<dyn Iterator<Item = DResult<Self, Self::Quad<'s>>> + 't>
     where
-        S: sophia_api::term::matcher::TermMatcher + 's,
-        P: sophia_api::term::matcher::TermMatcher + 's,
-        O: sophia_api::term::matcher::TermMatcher + 's,
-        G: sophia_api::term::matcher::GraphNameMatcher + 's,
+        's: 't,
+        S: sophia_api::term::matcher::TermMatcher + 't,
+        P: sophia_api::term::matcher::TermMatcher + 't,
+        O: sophia_api::term::matcher::TermMatcher + 't,
+        G: sophia_api::term::matcher::GraphNameMatcher + 't,
     {
         if let Some(gc) = gm.constant() {
             let gc = gc.map(|t| t.borrow_term());
@@ -240,18 +241,19 @@ impl<TI: GraphNameIndex> Dataset for GenericFastDataset<TI> {
     }
 
     #[allow(refining_impl_trait)]
-    fn quads_matching<'s, S, P, O, G>(
+    fn quads_matching<'s, 't, S, P, O, G>(
         &'s self,
         sm: S,
         pm: P,
         om: O,
         gm: G,
-    ) -> Box<dyn Iterator<Item = DResult<Self, Self::Quad<'s>>> + 's>
+    ) -> Box<dyn Iterator<Item = DResult<Self, Self::Quad<'s>>> + 't>
     where
-        S: sophia_api::term::matcher::TermMatcher + 's,
-        P: sophia_api::term::matcher::TermMatcher + 's,
-        O: sophia_api::term::matcher::TermMatcher + 's,
-        G: sophia_api::term::matcher::GraphNameMatcher + 's,
+        's: 't,
+        S: sophia_api::term::matcher::TermMatcher + 't,
+        P: sophia_api::term::matcher::TermMatcher + 't,
+        O: sophia_api::term::matcher::TermMatcher + 't,
+        G: sophia_api::term::matcher::GraphNameMatcher + 't,
     {
         let si = match sm.constant().map(|t| self.terms.get_index(t.borrow_term())) {
             None => None,

--- a/inmem/src/dataset/_iter.rs
+++ b/inmem/src/dataset/_iter.rs
@@ -10,10 +10,10 @@ use crate::index::{GraphNameIndex, TermIndex};
 pub struct GspoMatchingIterator<'a, TI, GM, SM, PM, OM>
 where
     TI: TermIndex + 'a,
-    GM: GraphNameMatcher + 'a,
-    SM: TermMatcher + 'a,
-    PM: TermMatcher + 'a,
-    OM: TermMatcher + 'a,
+    GM: GraphNameMatcher,
+    SM: TermMatcher,
+    PM: TermMatcher,
+    OM: TermMatcher,
 {
     terms: &'a TI,
     gspo: BTreeSetIter<'a, [TI::Index; 4]>,
@@ -23,13 +23,14 @@ where
     o: TermData<'a, TI, OM>,
 }
 
-impl<'a, TI, GM, SM, PM, OM> GspoMatchingIterator<'a, TI, GM, SM, PM, OM>
+impl<'a, 'b, TI, GM, SM, PM, OM> GspoMatchingIterator<'a, TI, GM, SM, PM, OM>
 where
+    'a: 'b,
     TI: GraphNameIndex + 'a,
-    GM: GraphNameMatcher + 'a,
-    SM: TermMatcher + 'a,
-    PM: TermMatcher + 'a,
-    OM: TermMatcher + 'a,
+    GM: GraphNameMatcher + 'b,
+    SM: TermMatcher + 'b,
+    PM: TermMatcher + 'b,
+    OM: TermMatcher + 'b,
 {
     pub fn boxed(
         terms: &'a TI,
@@ -38,7 +39,7 @@ where
         sm: SM,
         pm: PM,
         om: OM,
-    ) -> Box<dyn Iterator<Item = Result<Qud<'a, TI>, TI::Error>> + 'a> {
+    ) -> Box<dyn Iterator<Item = Result<Qud<'a, TI>, TI::Error>> + 'b> {
         match gspo.clone().next() {
             None => Box::new(empty()),
             Some(first) => Box::new(Self::new(terms, gspo, gm, sm, pm, om, first).map(Ok)),
@@ -75,10 +76,10 @@ pub type Qud<'a, TI> = Gspo<<<TI as TermIndex>::Term as Term>::BorrowTerm<'a>>;
 impl<'a, TI, GM, SM, PM, OM> Iterator for GspoMatchingIterator<'a, TI, GM, SM, PM, OM>
 where
     TI: GraphNameIndex + 'a,
-    GM: GraphNameMatcher + 'a,
-    SM: TermMatcher + 'a,
-    PM: TermMatcher + 'a,
-    OM: TermMatcher + 'a,
+    GM: GraphNameMatcher,
+    SM: TermMatcher,
+    PM: TermMatcher,
+    OM: TermMatcher,
 {
     type Item = Qud<'a, TI>;
 
@@ -122,9 +123,9 @@ where
 pub struct BcdMatchingIterator<'a, TI, BM, CM, DM>
 where
     TI: GraphNameIndex + 'a,
-    BM: GraphNameMatcher + 'a,
-    CM: GraphNameMatcher + 'a,
-    DM: GraphNameMatcher + 'a,
+    BM: GraphNameMatcher,
+    CM: GraphNameMatcher,
+    DM: GraphNameMatcher,
 {
     terms: &'a TI,
     abcd: Range<'a, [TI::Index; 4]>,
@@ -134,12 +135,13 @@ where
     d: GraphNameData<'a, TI, DM>,
 }
 
-impl<'a, TI, BM, CM, DM> BcdMatchingIterator<'a, TI, BM, CM, DM>
+impl<'a, 'b, TI, BM, CM, DM> BcdMatchingIterator<'a, TI, BM, CM, DM>
 where
+    'a: 'b,
     TI: GraphNameIndex + 'a,
-    BM: GraphNameMatcher + 'a,
-    CM: GraphNameMatcher + 'a,
-    DM: GraphNameMatcher + 'a,
+    BM: GraphNameMatcher + 'b,
+    CM: GraphNameMatcher + 'b,
+    DM: GraphNameMatcher + 'b,
 {
     pub fn boxed<F>(
         terms: &'a TI,
@@ -148,7 +150,7 @@ where
         cm: CM,
         dm: DM,
         mut to_gspo: F,
-    ) -> Box<dyn Iterator<Item = Result<Qud<'a, TI>, TI::Error>> + 'a>
+    ) -> Box<dyn Iterator<Item = Result<Qud<'a, TI>, TI::Error>> + 'b>
     where
         F: FnMut(GnQuad<'a, TI>) -> GnQuad<'a, TI> + 'a,
     {
@@ -199,9 +201,9 @@ type GnQuad<'a, TI> = [GraphName<<<TI as TermIndex>::Term as Term>::BorrowTerm<'
 impl<'a, TI, BM, CM, DM> Iterator for BcdMatchingIterator<'a, TI, BM, CM, DM>
 where
     TI: GraphNameIndex + 'a,
-    BM: GraphNameMatcher + 'a,
-    CM: GraphNameMatcher + 'a,
-    DM: GraphNameMatcher + 'a,
+    BM: GraphNameMatcher,
+    CM: GraphNameMatcher,
+    DM: GraphNameMatcher,
 {
     type Item = GnQuad<'a, TI>;
 
@@ -239,8 +241,8 @@ where
 pub struct CdMatchingIterator<'a, TI, CM, DM>
 where
     TI: GraphNameIndex + 'a,
-    CM: GraphNameMatcher + 'a,
-    DM: GraphNameMatcher + 'a,
+    CM: GraphNameMatcher,
+    DM: GraphNameMatcher,
 {
     terms: &'a TI,
     abcd: Range<'a, [TI::Index; 4]>,
@@ -250,11 +252,12 @@ where
     d: GraphNameData<'a, TI, DM>,
 }
 
-impl<'a, TI, CM, DM> CdMatchingIterator<'a, TI, CM, DM>
+impl<'a, 'b, TI, CM, DM> CdMatchingIterator<'a, TI, CM, DM>
 where
+    'a: 'b,
     TI: GraphNameIndex + 'a,
-    CM: GraphNameMatcher + 'a,
-    DM: GraphNameMatcher + 'a,
+    CM: GraphNameMatcher + 'b,
+    DM: GraphNameMatcher + 'b,
 {
     pub fn boxed<F>(
         terms: &'a TI,
@@ -262,7 +265,7 @@ where
         cm: CM,
         dm: DM,
         mut to_gspo: F,
-    ) -> Box<dyn Iterator<Item = Result<Qud<'a, TI>, TI::Error>> + 'a>
+    ) -> Box<dyn Iterator<Item = Result<Qud<'a, TI>, TI::Error>> + 'b>
     where
         F: FnMut(GnQuad<'a, TI>) -> GnQuad<'a, TI> + 'a,
     {
@@ -308,8 +311,8 @@ where
 impl<'a, TI, CM, DM> Iterator for CdMatchingIterator<'a, TI, CM, DM>
 where
     TI: GraphNameIndex + 'a,
-    CM: GraphNameMatcher + 'a,
-    DM: GraphNameMatcher + 'a,
+    CM: GraphNameMatcher,
+    DM: GraphNameMatcher,
 {
     type Item = GnQuad<'a, TI>;
 
@@ -342,7 +345,7 @@ struct GraphNameData<'a, TI, M>
 where
     TI: TermIndex,
     TI::Term: 'a,
-    M: GraphNameMatcher + 'a,
+    M: GraphNameMatcher,
 {
     m: M,
     i: TI::Index,
@@ -354,7 +357,7 @@ impl<'a, TI, M> GraphNameData<'a, TI, M>
 where
     TI: GraphNameIndex,
     TI::Term: 'a,
-    M: GraphNameMatcher + 'a,
+    M: GraphNameMatcher,
 {
     fn uninit(m: M, i: TI::Index, terms: &'a TI) -> Self {
         let t = terms.get_graph_name(i);

--- a/inmem/src/graph.rs
+++ b/inmem/src/graph.rs
@@ -43,16 +43,17 @@ impl<TI: TermIndex> Graph for GenericLightGraph<TI> {
     }
 
     #[allow(refining_impl_trait)]
-    fn triples_matching<'s, S, P, O>(
+    fn triples_matching<'s, 't, S, P, O>(
         &'s self,
         sm: S,
         pm: P,
         om: O,
-    ) -> Box<dyn Iterator<Item = GResult<Self, Self::Triple<'s>>> + 's>
+    ) -> Box<dyn Iterator<Item = GResult<Self, Self::Triple<'s>>> + 't>
     where
-        S: sophia_api::term::matcher::TermMatcher + 's,
-        P: sophia_api::term::matcher::TermMatcher + 's,
-        O: sophia_api::term::matcher::TermMatcher + 's,
+        's: 't,
+        S: sophia_api::term::matcher::TermMatcher + 't,
+        P: sophia_api::term::matcher::TermMatcher + 't,
+        O: sophia_api::term::matcher::TermMatcher + 't,
     {
         if let Some(sc) = sm.constant() {
             let Some(si) = self.terms.get_index(sc.borrow_term()) else {
@@ -180,16 +181,17 @@ impl<TI: TermIndex> Graph for GenericFastGraph<TI> {
     }
 
     #[allow(refining_impl_trait)]
-    fn triples_matching<'s, S, P, O>(
+    fn triples_matching<'s, 't, S, P, O>(
         &'s self,
         sm: S,
         pm: P,
         om: O,
-    ) -> Box<dyn Iterator<Item = GResult<Self, Self::Triple<'s>>> + 's>
+    ) -> Box<dyn Iterator<Item = GResult<Self, Self::Triple<'s>>> + 't>
     where
-        S: sophia_api::term::matcher::TermMatcher + 's,
-        P: sophia_api::term::matcher::TermMatcher + 's,
-        O: sophia_api::term::matcher::TermMatcher + 's,
+        's: 't,
+        S: sophia_api::term::matcher::TermMatcher + 't,
+        P: sophia_api::term::matcher::TermMatcher + 't,
+        O: sophia_api::term::matcher::TermMatcher + 't,
     {
         let si = match sm.constant().map(|t| self.terms.get_index(t.borrow_term())) {
             None => None,

--- a/inmem/src/graph/_iter.rs
+++ b/inmem/src/graph/_iter.rs
@@ -9,9 +9,9 @@ use crate::index::TermIndex;
 pub struct SpoMatchingIterator<'a, TI, SM, PM, OM>
 where
     TI: TermIndex + 'a,
-    SM: TermMatcher + 'a,
-    PM: TermMatcher + 'a,
-    OM: TermMatcher + 'a,
+    SM: TermMatcher,
+    PM: TermMatcher,
+    OM: TermMatcher,
 {
     terms: &'a TI,
     spo: BTreeSetIter<'a, [TI::Index; 3]>,
@@ -20,12 +20,13 @@ where
     o: TermData<'a, TI, OM>,
 }
 
-impl<'a, TI, SM, PM, OM> SpoMatchingIterator<'a, TI, SM, PM, OM>
+impl<'a, 'b, TI, SM, PM, OM> SpoMatchingIterator<'a, TI, SM, PM, OM>
 where
+    'a: 'b,
     TI: TermIndex + 'a,
-    SM: TermMatcher + 'a,
-    PM: TermMatcher + 'a,
-    OM: TermMatcher + 'a,
+    SM: TermMatcher + 'b,
+    PM: TermMatcher + 'b,
+    OM: TermMatcher + 'b,
 {
     pub fn boxed(
         terms: &'a TI,
@@ -33,7 +34,7 @@ where
         sm: SM,
         pm: PM,
         om: OM,
-    ) -> Box<dyn Iterator<Item = Result<Trpl<'a, TI>, TI::Error>> + 'a> {
+    ) -> Box<dyn Iterator<Item = Result<Trpl<'a, TI>, TI::Error>> + 'b> {
         match spo.clone().next() {
             None => Box::new(empty()),
             Some(first) => Box::new(Self::new(terms, spo, sm, pm, om, first).map(Ok)),
@@ -67,9 +68,9 @@ type Trpl<'a, TI> = [<<TI as TermIndex>::Term as Term>::BorrowTerm<'a>; 3];
 impl<'a, TI, SM, PM, OM> Iterator for SpoMatchingIterator<'a, TI, SM, PM, OM>
 where
     TI: TermIndex + 'a,
-    SM: TermMatcher + 'a,
-    PM: TermMatcher + 'a,
-    OM: TermMatcher + 'a,
+    SM: TermMatcher,
+    PM: TermMatcher,
+    OM: TermMatcher,
 {
     type Item = Trpl<'a, TI>;
 
@@ -106,8 +107,8 @@ where
 pub struct BcMatchingIterator<'a, TI, BM, CM>
 where
     TI: TermIndex + 'a,
-    BM: TermMatcher + 'a,
-    CM: TermMatcher + 'a,
+    BM: TermMatcher,
+    CM: TermMatcher,
 {
     terms: &'a TI,
     abc: Range<'a, [TI::Index; 3]>,
@@ -116,11 +117,12 @@ where
     c: TermData<'a, TI, CM>,
 }
 
-impl<'a, TI, BM, CM> BcMatchingIterator<'a, TI, BM, CM>
+impl<'a, 'b, TI, BM, CM> BcMatchingIterator<'a, TI, BM, CM>
 where
+    'a: 'b,
     TI: TermIndex + 'a,
-    BM: TermMatcher + 'a,
-    CM: TermMatcher + 'a,
+    BM: TermMatcher + 'b,
+    CM: TermMatcher + 'b,
 {
     pub fn boxed<F>(
         terms: &'a TI,
@@ -128,9 +130,9 @@ where
         bm: BM,
         cm: CM,
         mut to_spo: F,
-    ) -> Box<dyn Iterator<Item = Result<Trpl<'a, TI>, TI::Error>> + 'a>
+    ) -> Box<dyn Iterator<Item = Result<Trpl<'a, TI>, TI::Error>> + 'b>
     where
-        F: FnMut(Trpl<'a, TI>) -> Trpl<'a, TI> + 'a,
+        F: FnMut(Trpl<'a, TI>) -> Trpl<'a, TI> + 'b,
     {
         match abc.clone().next() {
             None => Box::new(empty()),
@@ -164,8 +166,8 @@ where
 impl<'a, TI, BM, CM> Iterator for BcMatchingIterator<'a, TI, BM, CM>
 where
     TI: TermIndex + 'a,
-    BM: TermMatcher + 'a,
-    CM: TermMatcher + 'a,
+    BM: TermMatcher,
+    CM: TermMatcher,
 {
     type Item = Trpl<'a, TI>;
 
@@ -195,7 +197,7 @@ pub struct TermData<'a, TI, M>
 where
     TI: TermIndex,
     TI::Term: 'a,
-    M: TermMatcher + 'a,
+    M: TermMatcher,
 {
     pub m: M,
     pub i: TI::Index,
@@ -207,7 +209,7 @@ impl<'a, TI, M> TermData<'a, TI, M>
 where
     TI: TermIndex,
     TI::Term: 'a,
-    M: TermMatcher + 'a,
+    M: TermMatcher,
 {
     pub fn uninit(m: M, i: TI::Index, terms: &'a TI) -> Self {
         let t = terms.get_term(i);


### PR DESCRIPTION
This stop propagating the lifetime of the matchers passed to Graph::triples_matching and Dataset::quads_matching to the triples returned by the resulting iterator.

Fixes #188