### PR TITLE
Bump json ld dep

### DIFF
--- a/jsonld/Cargo.toml
+++ b/jsonld/Cargo.toml
@@ -10,8 +10,6 @@ readme.workspace = true
 license.workspace = true
 keywords.workspace = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [features]
 default = []
 # This feature enables retrieval of context via file: URLs
@@ -20,12 +18,10 @@ file_url = ["dep:url"]
 http_client = ["json-ld/reqwest"]
 
 [dependencies]
-iref = "^2.2"
-json-ld = "0.15.1"
-json-syntax = "^0.9"
-langtag = "0.3.4"
-locspan = "^0.7.13"
-rdf-types = "^0.15.2"
+iref = "^3.1.2"
+json-ld = "^0.21"
+json-syntax = "^0.12"
+rdf-types = "^0.22"
 sophia_api.workspace = true
 sophia_iri.workspace = true
 sophia_term.workspace = true

--- a/jsonld/src/context.rs
+++ b/jsonld/src/context.rs
@@ -1,20 +1,16 @@
 //! Utility trait to ease the loading of JSON-LD Contexts
 
-use std::{borrow::Borrow, sync::Arc};
+use std::borrow::Borrow;
+use std::sync::Arc;
 
-use json_ld::{
-    ExtractContext, RemoteDocument, RemoteDocumentReference,
-    syntax::{Value, context::Value as ContextValue},
-};
+use json_ld::{ExtractContext, RemoteContextReference, RemoteDocument};
 use json_syntax::Parse;
-use locspan::{Location, Span};
 use sophia_iri::Iri;
 
 use crate::vocabulary::ArcIri;
 
 /// Type alias for the context references used by the JSON-LD options.
-pub type ContextRef =
-    RemoteDocumentReference<ArcIri, Location<ArcIri, Span>, ContextValue<Location<ArcIri, Span>>>;
+pub type ContextRef = RemoteContextReference<ArcIri>;
 
 /// Anything that can be turned into a [`ContextRef`]
 pub trait IntoContextRef {
@@ -30,7 +26,7 @@ impl IntoContextRef for ContextRef {
 
 impl<T: Borrow<str>> IntoContextRef for Iri<T> {
     fn into_context_ref(self) -> ContextRef {
-        RemoteDocumentReference::Iri(self.map_unchecked(|t| Arc::from(t.borrow())))
+        ContextRef::Iri(self.map_unchecked(|t| Arc::from(t.borrow())))
     }
 }
 
@@ -46,11 +42,11 @@ impl TryIntoContextRef for &str {
     type Error = Box<dyn std::error::Error>;
 
     fn try_into_context_ref(self) -> Result<ContextRef, Self::Error> {
-        let iri = ArcIri::new_unchecked("x-string://".into());
-        let doc = Value::parse_str(self, |span| locspan::Location::new(iri.clone(), span))?;
-        let context =
-            Value::extract_context(doc).map_err(|e| format!("Could not extract @context: {e}"))?;
+        let (doc, _) = json_ld::syntax::Value::parse_str(self)?;
+        let context = doc
+            .into_ld_context()
+            .map_err(|e| format!("Could not extract @context: {e}"))?;
         let rdoc = RemoteDocument::new(None, None, context);
-        Ok(RemoteDocumentReference::Loaded(rdoc))
+        Ok(ContextRef::Loaded(rdoc))
     }
 }

--- a/jsonld/src/error.rs
+++ b/jsonld/src/error.rs
@@ -1,11 +1,7 @@
 //! JSON-LD errors.
 
 use crate::options::ProcessingMode;
-use crate::vocabulary::ArcIri;
 use json_ld::ExpandError;
-use json_syntax::parse::Error;
-use locspan::{Location, Meta, Span};
-use std::fmt::Display;
 use std::sync::PoisonError;
 
 /// JSON-LD error
@@ -13,22 +9,12 @@ use std::sync::PoisonError;
 #[non_exhaustive]
 pub enum JsonLdError {
     /// Invalid JSON encountered while parsing.
-    #[error("invalid JSON at {location:?}: {error}")]
-    InvalidJson {
-        /// The JSON parsing error
-        error: Error<Location<ArcIri, Span>>,
-        /// The location where the error occurred
-        location: Location<ArcIri, Span>,
-    },
+    #[error("invalid JSON: {0}")]
+    InvalidJson(#[from] json_syntax::parse::Error),
 
     /// An invalid JSON literal was encountered when serializing.
-    #[error("invalid JSON literal at {location:?}: {error}")]
-    InvalidJsonLiteral {
-        /// The JSON parsing error
-        error: Error<Span>,
-        /// The location where the error occurred
-        location: Span,
-    },
+    #[error("invalid JSON literal: {0}")]
+    InvalidJsonLiteral(json_syntax::parse::Error),
 
     /// An IO error.
     #[error("IO Error: {0}")]
@@ -55,31 +41,14 @@ pub enum JsonLdError {
     Utf8(#[from] std::string::FromUtf8Error),
 }
 
-impl From<Meta<Error<Location<ArcIri, Span>>, Location<ArcIri, Span>>> for JsonLdError {
-    fn from(other: Meta<Error<Location<ArcIri, Span>>, Location<ArcIri, Span>>) -> Self {
-        let Meta(error, location) = other;
-        Self::InvalidJson { error, location }
-    }
-}
-
-impl From<Meta<Error<Span>, Span>> for JsonLdError {
-    fn from(other: Meta<Error<Span>, Span>) -> Self {
-        let Meta(error, location) = other;
-        Self::InvalidJsonLiteral { error, location }
-    }
-}
-
 impl<T> From<PoisonError<T>> for JsonLdError {
     fn from(value: PoisonError<T>) -> Self {
         Self::PoisonnedLock(format!("{value}"))
     }
 }
 
-impl<M, E, C> From<ExpandError<M, E, C>> for JsonLdError
-where
-    ExpandError<M, E, C>: Display,
-{
-    fn from(value: ExpandError<M, E, C>) -> Self {
+impl From<ExpandError> for JsonLdError {
+    fn from(value: ExpandError) -> Self {
         Self::ExpandError(format!("{value}"))
     }
 }

--- a/jsonld/src/loader.rs
+++ b/jsonld/src/loader.rs
@@ -5,24 +5,12 @@
 //! * [`FileUrlLoader`]: loads documents from file: URLs
 //! * [`HttpLoader`]: loads documents directly from the web (only if the `http_client` feature is enabled)
 //! * [`ChainLoader`]: loads document from the first loader, otherwise falls back to the second one.
-use std::sync::Arc;
-
-use json_syntax::Value;
-use locspan::Location;
-use sophia_iri::Iri;
-
-pub use json_ld::future::{BoxFuture, FutureExt};
 
 /// A dummy document loader, that does not load anything.
-pub type NoLoader =
-    json_ld::NoLoader<Iri<Arc<str>>, Location<Iri<Arc<str>>>, Value<Location<Iri<Arc<str>>>>>;
+pub use json_ld::NoLoader;
 
-/// A document loader that can load documents from the file system,
-/// by mapping directories to specific URLs.
-///
-/// See [`json_ld::FsLoader`]
-pub type FsLoader =
-    json_ld::FsLoader<Iri<Arc<str>>, Location<Iri<Arc<str>>>, Value<Location<Iri<Arc<str>>>>>;
+mod fs_loader;
+pub use fs_loader::*;
 
 mod static_loader;
 pub use static_loader::*;
@@ -36,8 +24,7 @@ pub use file_url_loader::*;
 /// A document loader that can load documents from the web.
 ///
 /// See [`json_ld::ReqwestLoader`]
-pub type HttpLoader =
-    json_ld::ReqwestLoader<Iri<Arc<str>>, Location<Iri<Arc<str>>>, Value<Location<Iri<Arc<str>>>>>;
+pub use json_ld::ReqwestLoader as HttpLoader;
 
 mod chain_loader;
 pub use chain_loader::*;

--- a/jsonld/src/loader/chain_loader.rs
+++ b/jsonld/src/loader/chain_loader.rs
@@ -1,9 +1,5 @@
-use std::fmt::Debug;
-
-use json_ld::Loader;
-use json_ld::future::{BoxFuture, FutureExt};
-use json_syntax::Value;
-use locspan::Location;
+use iref::{Iri, IriBuf};
+use json_ld::{LoadError, Loader, RemoteDocument};
 
 /// * [`ChainLoader`]: loads document from the first loader, otherwise falls back to the second one.
 #[derive(Clone, Debug, Default)]
@@ -16,43 +12,15 @@ impl<L1, L2> ChainLoader<L1, L2> {
     }
 }
 
-impl<I, L1, L2> Loader<I, Location<I>> for ChainLoader<L1, L2>
+impl<L1, L2> Loader for ChainLoader<L1, L2>
 where
-    I: Clone + Send + Sync,
-    L1: Loader<I, Location<I>, Output = Value<Location<I>>> + Send,
-    L2: Loader<I, Location<I>, Output = Value<Location<I>>> + Send,
-    L1::Error: Debug + Send,
-    L2::Error: Debug,
+    L1: Loader + Sync,
+    L2: Loader + Sync,
 {
-    type Output = Value<Location<I>>;
-
-    type Error = ChainLoaderError<L1::Error, L2::Error>;
-
-    fn load_with<'a>(
-        &'a mut self,
-        vocabulary: &'a mut (impl Sync + Send + rdf_types::IriVocabularyMut<Iri = I>),
-        url: I,
-    ) -> BoxFuture<'a, json_ld::LoadingResult<I, Location<I>, Self::Output, Self::Error>>
-    where
-        I: 'a,
-    {
-        async {
-            match self.0.load_with(vocabulary, url.clone()).await {
-                Ok(doc) => Ok(doc),
-                Err(err1) => match self.1.load_with(vocabulary, url).await {
-                    Ok(doc) => Ok(doc),
-                    Err(err2) => Err(ChainLoaderError(err1, err2)),
-                },
-            }
+    async fn load(&self, url: &Iri) -> Result<RemoteDocument<IriBuf>, LoadError> {
+        match self.0.load(url).await {
+            Ok(doc) => Ok(doc),
+            Err(_) => self.1.load(url).await,
         }
-        .boxed()
     }
 }
-
-/// Error type raised by [`ChainLoader`]
-#[derive(thiserror::Error, Debug)]
-#[error("Document not found {0}")]
-pub struct ChainLoaderError<E1, E2>(E1, E2)
-where
-    E1: Debug,
-    E2: Debug;

--- a/jsonld/src/loader/closure_loader.rs
+++ b/jsonld/src/loader/closure_loader.rs
@@ -1,10 +1,10 @@
-use super::{Arc, Iri, Value};
-use json_ld::future::{BoxFuture, FutureExt};
-use json_ld::{Loader, RemoteDocument};
+use iref::{Iri, IriBuf};
+use json_ld::{LoadError, Loader, RemoteDocument};
 use json_syntax::Parse;
-use locspan::{Location, Meta};
-use rdf_types::IriVocabulary;
-use std::fmt;
+use std::future::Future;
+use std::pin::Pin;
+
+type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
 /// Closure loader.
 ///
@@ -13,50 +13,28 @@ pub struct ClosureLoader<F> {
     closure: F,
 }
 
-impl<'f, F> Loader<Iri<Arc<str>>, Location<Iri<Arc<str>>>> for ClosureLoader<F>
+impl<F> Loader for ClosureLoader<F>
 where
-    F: Send + FnMut(Iri<String>) -> BoxFuture<'f, Result<String, String>>,
+    F: Send + Sync + for<'a> Fn(sophia_iri::Iri<&'a str>) -> BoxFuture<'a, Result<String, String>>,
 {
-    type Output = Value<Location<Iri<Arc<str>>>>;
-    type Error = ClosureLoaderError;
-
-    fn load_with<'a>(
-        &'a mut self,
-        vocabulary: &'a mut (impl Sync + Send + IriVocabulary<Iri = Iri<Arc<str>>>),
-        url: Iri<Arc<str>>,
-    ) -> BoxFuture<
-        'a,
-        Result<
-            RemoteDocument<Iri<Arc<str>>, Location<Iri<Arc<str>>>, Value<Location<Iri<Arc<str>>>>>,
-            Self::Error,
-        >,
-    >
-    where
-        Iri<Arc<str>>: 'a,
-    {
-        async move {
-            let iri = vocabulary.iri(&url).unwrap();
-            let url_str = iri.as_str().to_string();
-            let content = (self.closure)(Iri::new_unchecked(url_str))
-                .await
-                .map_err(Self::Error::Internal)?;
-            let doc = json_syntax::Value::parse_str(content.as_str(), |span| {
-                locspan::Location::new(url.clone(), span)
-            })
-            .map_err(Self::Error::Parse)?;
-            Ok(RemoteDocument::new(
-                Some(url),
-                Some("application/ld+json".parse().unwrap()),
-                doc,
-            ))
-        }
-        .boxed()
+    async fn load(&self, url: &Iri) -> Result<RemoteDocument<IriBuf>, LoadError> {
+        let content = (self.closure)(sophia_iri::Iri::new_unchecked(url.as_str()))
+            .await
+            .map_err(|e| LoadError::new(url.to_owned(), ClosureLoaderError::Internal(e)))?;
+        let (doc, _) = json_syntax::Value::parse_str(&content).map_err(|e| {
+            LoadError::new(url.to_owned(), ClosureLoaderError::Parse(format!("{e}")))
+        })?;
+        Ok(RemoteDocument::new(
+            Some(url.to_owned()),
+            Some("application/ld+json".parse().unwrap()),
+            doc,
+        ))
     }
 }
 
-impl<'f, F> ClosureLoader<F>
+impl<F> ClosureLoader<F>
 where
-    F: Send + FnMut(Iri<String>) -> BoxFuture<'f, Result<String, String>>,
+    F: Send + Sync + for<'a> Fn(sophia_iri::Iri<&'a str>) -> BoxFuture<'a, Result<String, String>>,
 {
     /// Creates a new closure loader with the given closure.
     pub const fn new(f: F) -> Self {
@@ -65,23 +43,13 @@ where
 }
 
 /// Loading error.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum ClosureLoaderError {
     /// Error raised by the inner closure
+    #[error("{0}")]
     Internal(String),
 
     /// Parse error.
-    Parse(JsonParseError),
+    #[error("parse error: {0}")]
+    Parse(String),
 }
-
-impl fmt::Display for ClosureLoaderError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Self::Internal(e) => e.fmt(f),
-            Self::Parse(e) => e.fmt(f),
-        }
-    }
-}
-
-type JsonParseError =
-    Meta<json_syntax::parse::Error<Location<Iri<Arc<str>>>>, Location<Iri<Arc<str>>>>;

--- a/jsonld/src/loader/file_url_loader.rs
+++ b/jsonld/src/loader/file_url_loader.rs
@@ -1,10 +1,6 @@
-use super::{Arc, Iri, Value};
-use json_ld::future::{BoxFuture, FutureExt};
-use json_ld::{Loader, RemoteDocument};
+use iref::{Iri, IriBuf};
+use json_ld::{LoadError, Loader, RemoteDocument};
 use json_syntax::Parse;
-use locspan::{Location, Meta};
-use rdf_types::IriVocabulary;
-use std::fmt;
 use std::fs::File;
 use std::io::{BufReader, Read};
 use url::Url;
@@ -18,56 +14,43 @@ use url::Url;
 #[derive(Clone, Copy, Debug, Default)]
 pub struct FileUrlLoader {}
 
-impl Loader<Iri<Arc<str>>, Location<Iri<Arc<str>>>> for FileUrlLoader {
-    type Output = Value<Location<Iri<Arc<str>>>>;
-    type Error = FileUrlLoaderError;
-
-    fn load_with<'a>(
-        &'a mut self,
-        vocabulary: &'a mut (impl Sync + Send + IriVocabulary<Iri = Iri<Arc<str>>>),
-        url: Iri<Arc<str>>,
-    ) -> BoxFuture<
-        'a,
-        Result<
-            RemoteDocument<Iri<Arc<str>>, Location<Iri<Arc<str>>>, Value<Location<Iri<Arc<str>>>>>,
-            Self::Error,
-        >,
-    >
-    where
-        Iri<Arc<str>>: 'a,
-    {
-        async move {
-            let iri = vocabulary.iri(&url).unwrap();
-            let url_str = iri.as_str();
-            if !url_str.starts_with("file:") {
-                return Err(Self::Error::NotFileUrl(url_str.into()));
-            }
-            let url_parsed = Url::parse(url_str).map_err(Self::Error::InvalidUrl)?;
-            let path = url_parsed
-                .to_file_path()
-                .map_err(|()| Self::Error::BadFileUrl(url_str.into()))?;
-            let file = File::open(path).map_err(Self::Error::IO)?;
-            let mut buf_reader = BufReader::new(file);
-            let mut contents = String::new();
-            buf_reader
-                .read_to_string(&mut contents)
-                .map_err(Self::Error::IO)?;
-            let doc = json_syntax::Value::parse_str(contents.as_str(), |span| {
-                locspan::Location::new(url.clone(), span)
-            })
-            .map_err(Self::Error::Parse)?;
-            Ok(RemoteDocument::new(
-                Some(url),
-                Some("application/ld+json".parse().unwrap()),
-                doc,
-            ))
+impl Loader for FileUrlLoader {
+    async fn load(&self, url: &Iri) -> Result<RemoteDocument<IriBuf>, LoadError> {
+        let url_str = url.as_str();
+        if !url_str.starts_with("file:") {
+            return Err(LoadError::new(
+                url.to_owned(),
+                FileUrlLoaderError::NotFileUrl(url_str.to_string()),
+            ));
         }
-        .boxed()
+        let url_parsed = Url::parse(url_str)
+            .map_err(|e| LoadError::new(url.to_owned(), FileUrlLoaderError::InvalidUrl(e)))?;
+        let path = url_parsed.to_file_path().map_err(|()| {
+            LoadError::new(
+                url.to_owned(),
+                FileUrlLoaderError::BadFileUrl(url_str.to_string()),
+            )
+        })?;
+        let file = File::open(path)
+            .map_err(|e| LoadError::new(url.to_owned(), FileUrlLoaderError::IO(e)))?;
+        let mut buf_reader = BufReader::new(file);
+        let mut contents = String::new();
+        buf_reader
+            .read_to_string(&mut contents)
+            .map_err(|e| LoadError::new(url.to_owned(), FileUrlLoaderError::IO(e)))?;
+        let (doc, _) = json_syntax::Value::parse_str(&contents).map_err(|e| {
+            LoadError::new(url.to_owned(), FileUrlLoaderError::Parse(format!("{e}")))
+        })?;
+        Ok(RemoteDocument::new(
+            Some(url.to_owned()),
+            Some("application/ld+json".parse().unwrap()),
+            doc,
+        ))
     }
 }
 
 impl FileUrlLoader {
-    /// Creates a new file system loader with the given content `parser`.
+    /// Creates a new file system loader.
     #[must_use]
     pub fn new() -> Self {
         Self::default()
@@ -75,35 +58,25 @@ impl FileUrlLoader {
 }
 
 /// Loading error.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum FileUrlLoaderError {
     /// URL parse error
+    #[error("{0}")]
     InvalidUrl(url::ParseError),
 
     /// URL is not a file
+    #[error("Not a file: URL: {0}")]
     NotFileUrl(String),
 
     /// file: URL does not encode a correct path
+    #[error("Invalid path in {0}")]
     BadFileUrl(String),
 
     /// IO error.
+    #[error("{0}")]
     IO(std::io::Error),
 
     /// Parse error.
-    Parse(JsonParseError),
+    #[error("parse error: {0}")]
+    Parse(String),
 }
-
-impl fmt::Display for FileUrlLoaderError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Self::InvalidUrl(e) => e.fmt(f),
-            Self::NotFileUrl(url) => write!(f, "Not a file: URL: {url}"),
-            Self::BadFileUrl(url) => write!(f, "Invalid path in {url}"),
-            Self::IO(e) => e.fmt(f),
-            Self::Parse(e) => e.fmt(f),
-        }
-    }
-}
-
-type JsonParseError =
-    Meta<json_syntax::parse::Error<Location<Iri<Arc<str>>>>, Location<Iri<Arc<str>>>>;

--- a/jsonld/src/loader/fs_loader.rs
+++ b/jsonld/src/loader/fs_loader.rs
@@ -1,0 +1,53 @@
+use std::{
+    borrow::Borrow,
+    path::{Path, PathBuf},
+};
+
+use sophia_iri::Iri;
+
+/// A document loader that can load documents from the file system,
+/// by mapping directories to specific URLs.
+///
+/// See [`json_ld::FsLoader`]
+#[derive(Default)]
+pub struct FsLoader(json_ld::FsLoader);
+
+impl FsLoader {
+    /// Constructor
+    pub fn new() -> Self {
+        Self(json_ld::FsLoader::new())
+    }
+
+    /// Bind the given IRI prefix to the given path.
+    ///
+    /// Any document with an IRI matching the given prefix will be loaded from the referenced local directory.
+    pub fn mount<T, P>(&mut self, url: Iri<T>, path: P)
+    where
+        T: Borrow<str> + ToString,
+        P: AsRef<Path>,
+    {
+        let iribuf = unsafe {
+            // SAFETY url is known to hold a valid IRI
+            iref::IriBuf::new_unchecked(url.unwrap().to_string())
+        };
+        self.0.mount(iribuf, path)
+    }
+
+    /// Returns the local file path associated to the given url if any.
+    pub fn filepath(&self, url: Iri<&str>) -> Option<PathBuf> {
+        let iri = unsafe {
+            // SAFETY url is known to hold a valid IRI
+            iref::Iri::new_unchecked(url.as_str())
+        };
+        self.0.filepath(iri)
+    }
+}
+
+impl json_ld::Loader for FsLoader {
+    async fn load(
+        &self,
+        url: &iref::Iri,
+    ) -> Result<json_ld::RemoteDocument<iref::IriBuf>, json_ld::LoadError> {
+        self.0.load(url).await
+    }
+}

--- a/jsonld/src/loader/static_loader.rs
+++ b/jsonld/src/loader/static_loader.rs
@@ -1,37 +1,19 @@
-use std::{collections::HashMap, fmt::Debug};
+use std::collections::HashMap;
 
-use json_ld::future::{BoxFuture, FutureExt};
-use json_ld::{Loader, RemoteDocument};
+use iref::{Iri, IriBuf};
+use json_ld::{LoadError, Loader, RemoteDocument};
 use json_syntax::Value;
-use locspan::{Location, Meta};
-use sophia_iri::IsIri;
-
-type JsonVal<I, S> = Value<Location<I, S>>;
-type MetaVal<I, S> = Meta<JsonVal<I, S>, Location<I, S>>;
 
 /// A document loader that stores a selected set of documents in memory.
 /// This is useful for stable (e.g. normative) contexts that are expected to be used a lot.
 ///
 /// See <https://www.w3.org/TR/json-ld11/#privacy>
-///
-/// NB: The type parameter `I` for IRI-indexes is bound to `IsIri`,
-/// meaning that they must allow the IRI to be retrieved without resorting on a [`Vocabulary`](rdf_types::Vocabulary).
-/// This restriction is required because cached values use indexes,
-/// and that we can not guarantee that the same vocabulary will be used each time a cached value is returned.
-#[derive(Clone, Debug)]
-pub struct StaticLoader<I, S> {
-    cache: HashMap<String, MetaVal<I, S>>,
+#[derive(Clone, Debug, Default)]
+pub struct StaticLoader {
+    cache: HashMap<String, Value>,
 }
 
-impl<I, S> Default for StaticLoader<I, S> {
-    fn default() -> Self {
-        Self {
-            cache: Default::default(),
-        }
-    }
-}
-
-impl<I: IsIri, S> StaticLoader<I, S> {
+impl StaticLoader {
     /// Creates a new [`StaticLoader`]
     #[must_use]
     pub fn new() -> Self {
@@ -39,42 +21,29 @@ impl<I: IsIri, S> StaticLoader<I, S> {
     }
 
     /// Extend this [`StaticLoader`] with another document
-    pub fn with(mut self, url: I, document: MetaVal<I, S>) -> Self {
-        self.cache.insert(url.borrow().into(), document);
+    pub fn with(mut self, url: &Iri, document: Value) -> Self {
+        self.cache.insert(url.as_str().to_string(), document);
         self
     }
 }
 
-impl<I, S> Loader<I, Location<I, S>> for StaticLoader<I, S>
-where
-    I: Clone + IsIri + Send,
-    S: Clone + Send,
-{
-    type Output = JsonVal<I, S>;
-
-    type Error = StaticLoaderError;
-
-    fn load_with<'a>(
-        &'a mut self,
-        _vocabulary: &'a mut (impl Sync + Send + rdf_types::IriVocabularyMut<Iri = I>),
-        url: I,
-    ) -> BoxFuture<'a, json_ld::LoadingResult<I, Location<I, S>, Self::Output, Self::Error>>
-    where
-        I: 'a,
-    {
-        async move {
-            self.cache
-                .get(url.borrow())
-                .ok_or_else(|| StaticLoaderError::NotFound(url.borrow().into()))
-                .map(|val| {
-                    RemoteDocument::new(
-                        Some(url),
-                        Some("application/ld+json".parse().unwrap()),
-                        val.clone(),
-                    )
-                })
-        }
-        .boxed()
+impl Loader for StaticLoader {
+    async fn load(&self, url: &Iri) -> Result<RemoteDocument<IriBuf>, LoadError> {
+        self.cache
+            .get(url.as_str())
+            .ok_or_else(|| {
+                LoadError::new(
+                    url.to_owned(),
+                    StaticLoaderError::NotFound(url.as_str().to_string()),
+                )
+            })
+            .map(|val| {
+                RemoteDocument::new(
+                    Some(url.to_owned()),
+                    Some("application/ld+json".parse().unwrap()),
+                    val.clone(),
+                )
+            })
     }
 }
 

--- a/jsonld/src/loader_factory.rs
+++ b/jsonld/src/loader_factory.rs
@@ -1,29 +1,16 @@
 //! I define trait for loader factories.
 //!
 
-use std::{fmt::Display, marker::PhantomData, sync::Arc};
+use std::marker::PhantomData;
 
 use json_ld::Loader;
-use json_syntax::Value;
-use locspan::Location;
-use sophia_iri::Iri;
 
 /// A trait for factory of document loaders.
 pub trait LoaderFactory {
     /// Type of loaders this factory yields.
-    type Loader<'l>: Loader<
-            Iri<Arc<str>>,
-            Location<Iri<Arc<str>>>,
-            Output = Value<Location<Iri<Arc<str>>>>,
-            Error = Self::LoaderError,
-        > + Send
-        + Sync
-        + 'l
+    type Loader<'l>: Loader + Send + Sync + 'l
     where
         Self: 'l;
-
-    /// Type of loader error.
-    type LoaderError: Display + Send;
 
     /// Yield a new loader.
     fn yield_loader(&self) -> Self::Loader<'_>;
@@ -37,11 +24,7 @@ pub struct DefaultLoaderFactory<L> {
 
 impl<L> DefaultLoaderFactory<L>
 where
-    L: Loader<Iri<Arc<str>>, Location<Iri<Arc<str>>>, Output = Value<Location<Iri<Arc<str>>>>>
-        + Default
-        + Send
-        + Sync,
-    L::Error: Display + Send,
+    L: Loader + Default + Send + Sync,
 {
     /// Create a new [`DefaultLoaderFactory`].
     #[inline]
@@ -53,18 +36,12 @@ where
 
 impl<L> LoaderFactory for DefaultLoaderFactory<L>
 where
-    L: Loader<Iri<Arc<str>>, Location<Iri<Arc<str>>>, Output = Value<Location<Iri<Arc<str>>>>>
-        + Default
-        + Send
-        + Sync,
-    L::Error: Display + Send,
+    L: Loader + Default + Send + Sync,
 {
     type Loader<'l>
         = L
     where
         Self: 'l;
-
-    type LoaderError = L::Error;
 
     #[inline]
     fn yield_loader(&self) -> Self::Loader<'_> {
@@ -81,10 +58,7 @@ pub struct ClosureLoaderFactory<L, F> {
 
 impl<L, F> ClosureLoaderFactory<L, F>
 where
-    L: Loader<Iri<Arc<str>>, Location<Iri<Arc<str>>>, Output = Value<Location<Iri<Arc<str>>>>>
-        + Send
-        + Sync,
-    L::Error: Display + Send,
+    L: Loader + Send + Sync,
     F: Fn() -> L,
 {
     /// Create a new [`ClosureLoaderFactory`] with given closure.
@@ -99,10 +73,7 @@ where
 
 impl<L> ClosureLoaderFactory<L, fn() -> L>
 where
-    L: Loader<Iri<Arc<str>>, Location<Iri<Arc<str>>>, Output = Value<Location<Iri<Arc<str>>>>>
-        + Send
-        + Sync,
-    L::Error: Display + Send,
+    L: Loader + Send + Sync,
 {
     /// Create a new [`ClosureLoaderFactory`] that yields loaders by cloning a template loader.
     #[inline]
@@ -116,18 +87,13 @@ where
 
 impl<L, F> LoaderFactory for ClosureLoaderFactory<L, F>
 where
-    L: Loader<Iri<Arc<str>>, Location<Iri<Arc<str>>>, Output = Value<Location<Iri<Arc<str>>>>>
-        + Send
-        + Sync,
-    L::Error: Display + Send,
+    L: Loader + Send + Sync,
     F: Fn() -> L,
 {
     type Loader<'l>
         = L
     where
         Self: 'l;
-
-    type LoaderError = L::Error;
 
     #[inline]
     fn yield_loader(&self) -> Self::Loader<'_> {

--- a/jsonld/src/options.rs
+++ b/jsonld/src/options.rs
@@ -1,17 +1,10 @@
 //! Defines types for configuring JSON-LD processing.
 
-use std::fmt::Display;
-use std::sync::Arc;
-
 use json_ld::Loader;
 pub use json_ld::Options;
 pub use json_ld::ProcessingMode;
 pub use json_ld::expansion::Policy;
 pub use json_ld::rdf::RdfDirection;
-use json_ld::syntax::context::Value as ContextValue;
-use json_syntax::Value;
-use locspan::Location;
-use locspan::Span;
 use sophia_iri::Iri;
 
 use crate::context::{ContextRef, IntoContextRef, TryIntoContextRef};
@@ -54,7 +47,7 @@ impl<LF> JsonLdOptions<LF> {
     ///
     /// [`base`]: https://www.w3.org/TR/json-ld11-api/#dom-jsonldoptions-base
     pub fn base(&self) -> Option<Iri<&str>> {
-        self.inner.base.as_ref().map(|i| i.as_ref())
+        self.inner.base.as_ref().map(Iri::as_ref)
     }
 
     /// [`compactArrays`] instructs the JSON-LD processor to replace arrays of one element with that element during [compaction].
@@ -231,8 +224,7 @@ impl<LF> JsonLdOptions<LF> {
         f: F,
     ) -> JsonLdOptions<ClosureLoaderFactory<L, F>>
     where
-        L: Loader<ArcIri, Location<Iri<Arc<str>>>, Output = Value<Location<ArcIri>>> + Send + Sync,
-        L::Error: Display + Send,
+        L: Loader + Send + Sync,
         F: Fn() -> L,
     {
         JsonLdOptions {
@@ -254,11 +246,7 @@ impl<LF> JsonLdOptions<LF> {
     /// [`JsonLdOptions::with_document_loader`],
     pub fn with_default_document_loader<L>(self) -> JsonLdOptions<DefaultLoaderFactory<L>>
     where
-        L: Loader<ArcIri, Location<Iri<Arc<str>>>, Output = Value<Location<ArcIri>>>
-            + Default
-            + Send
-            + Sync,
-        L::Error: Display + Send,
+        L: Loader + Default + Send + Sync,
     {
         JsonLdOptions {
             inner: self.inner,
@@ -282,11 +270,7 @@ impl<LF> JsonLdOptions<LF> {
         document_loader: L,
     ) -> JsonLdOptions<ClosureLoaderFactory<L, impl Fn() -> L>>
     where
-        L: Loader<ArcIri, Location<Iri<Arc<str>>>, Output = Value<Location<ArcIri>>>
-            + Clone
-            + Send
-            + Sync,
-        L::Error: Display + Send,
+        L: Loader + Clone + Send + Sync,
     {
         JsonLdOptions {
             inner: self.inner,
@@ -435,5 +419,4 @@ impl<LF> std::ops::Deref for JsonLdOptions<LF> {
 }
 
 /// Type alias for [`json_ld::Options`] as used in this crate.
-type InnerOptions =
-    json_ld::Options<ArcIri, Location<ArcIri, Span>, ContextValue<Location<ArcIri, Span>>>;
+type InnerOptions = json_ld::Options<ArcIri>;

--- a/jsonld/src/parser.rs
+++ b/jsonld/src/parser.rs
@@ -4,7 +4,6 @@ use std::{io::BufRead, sync::Arc};
 
 use json_ld::{JsonLdProcessor, RemoteDocument, ToRdfError};
 use json_syntax::{Parse, Value};
-use locspan::{Location, Span};
 use sophia_api::{prelude::QuadParser, quad::Spog};
 use sophia_iri::Iri;
 
@@ -29,7 +28,7 @@ mod test;
 ///
 /// ## Developers
 ///
-/// * the generic parameter `L` is the type of the [document loader](json_ld::Loader)
+/// * the generic parameter `LF` is the type of the [document loader](json_ld::Loader) [factory](crate::loader_factory)
 ///   (determined by the `options` parameters)
 ///
 /// ## WebAssembly
@@ -75,16 +74,12 @@ impl<LF> JsonLdParser<LF> {
     where
         LF: LoaderFactory,
     {
-        let gen_loc = Location::new(
-            Iri::new_unchecked(Arc::from("x-bnode-gen://")),
-            Span::default(),
-        );
-        let mut generator = rdf_types::generator::Blank::new().with_metadata(gen_loc);
-        let mut loader = self.options.document_loader();
+        let mut generator = rdf_types::generator::Blank::new();
+        let loader = self.options.document_loader();
         let mut vocab = ArcVoc {};
         let options = self.options.inner().clone();
         match data
-            .to_rdf_with_using(&mut vocab, &mut generator, &mut loader, options)
+            .to_rdf_with_using(&mut vocab, &mut generator, &loader, options)
             .await
         {
             Err(ToRdfError::Expand(err)) => JsonLdQuadSource::from_err(err),
@@ -108,12 +103,9 @@ impl<LF> JsonLdParser<LF> {
             .base()
             .unwrap_or(Iri::new_unchecked_const("x-string://"))
             .map_unchecked(Arc::from);
-        let json_res = Value::parse_str(txt, |span| Location::new(base.clone(), span));
-        let json = match json_res {
-            Ok(json) => json,
-            Err(err) => {
-                return JsonLdQuadSource::from_err(err);
-            }
+        let json = match Value::parse_str(txt) {
+            Ok((json, _)) => json,
+            Err(err) => return JsonLdQuadSource::from_err(err),
         };
         let doc = RemoteDocument::new(Some(base), None, json);
         self.parse_json(&doc).await

--- a/jsonld/src/parser/adapter.rs
+++ b/jsonld/src/parser/adapter.rs
@@ -1,11 +1,11 @@
-use rdf_types::{Id, Literal, Quad, Term, literal::Type};
+use rdf_types::{Id, Literal, LiteralType, Quad, Term};
 use sophia_api::{
     MownStr,
     quad::Spog,
-    term::{Term as SophiaTerm, TermKind},
+    term::{IriRef, Term as SophiaTerm, TermKind},
 };
 
-use crate::vocabulary::{ArcBnode, ArcIri, ArcTag};
+use crate::vocabulary::{ArcBnode, ArcIri};
 
 /// Sophia wrapper for `rdf_type` types
 #[repr(transparent)]
@@ -30,7 +30,7 @@ impl SophiaTerm for RdfTerm {
         self
     }
 
-    fn iri(&self) -> Option<sophia_api::term::IriRef<MownStr<'_>>> {
+    fn iri(&self) -> Option<IriRef<MownStr<'_>>> {
         match &self.0 {
             Term::Id(Id::Iri(iri)) => iri.iri(),
             _ => None,
@@ -46,16 +46,16 @@ impl SophiaTerm for RdfTerm {
 
     fn lexical_form(&self) -> Option<MownStr<'_>> {
         match &self.0 {
-            Term::Literal(lit) => Some(MownStr::from_ref(lit.value())),
+            Term::Literal(lit) => Some(MownStr::from_ref(lit.as_value())),
             _ => None,
         }
     }
 
-    fn datatype(&self) -> Option<sophia_api::term::IriRef<MownStr<'_>>> {
+    fn datatype(&self) -> Option<IriRef<MownStr<'_>>> {
         match &self.0 {
-            Term::Literal(lit) => match lit.type_() {
-                Type::Any(iri) => iri.iri(),
-                Type::LangString(_) => sophia_api::ns::rdf::langString.iri(),
+            Term::Literal(lit) => match &lit.type_ {
+                LiteralType::Any(iri) => iri.iri(),
+                LiteralType::LangString(_) => sophia_api::ns::rdf::langString.iri(),
             },
             _ => None,
         }
@@ -63,9 +63,11 @@ impl SophiaTerm for RdfTerm {
 
     fn language_tag(&self) -> Option<sophia_api::term::LanguageTag<MownStr<'_>>> {
         match &self.0 {
-            Term::Literal(lit) => match lit.type_() {
-                Type::LangString(tag) => Some(tag.as_ref().map_unchecked(MownStr::from_ref)),
-                Type::Any(_) => None,
+            Term::Literal(lit) => match &lit.type_ {
+                LiteralType::LangString(tag) => Some(sophia_api::term::LanguageTag::new_unchecked(
+                    MownStr::from_ref(tag.as_str()),
+                )),
+                LiteralType::Any(_) => None,
             },
             _ => None,
         }
@@ -103,6 +105,6 @@ pub fn convert_quad(q: RdfQuad) -> Spog<RdfTerm> {
 
 type RdfS = Id<ArcIri, ArcBnode>;
 type RdfP = Id<ArcIri, ArcBnode>;
-type RdfLit = Literal<Type<ArcIri, ArcTag>, String>;
+type RdfLit = Literal<ArcIri>;
 type RdfO = Term<RdfS, RdfLit>;
 type RdfQuad = Quad<RdfS, RdfP, RdfO, RdfS>;

--- a/jsonld/src/parser/test.rs
+++ b/jsonld/src/parser/test.rs
@@ -46,7 +46,7 @@ fn check_fs_loader() {
 // NB: the goal is NOT to check the loader itself -- we actually don't use it.
 #[test]
 fn check_static_loader() {
-    let options = JsonLdOptions::new().with_default_document_loader::<StaticLoader<_, _>>();
+    let options = JsonLdOptions::new().with_default_document_loader::<StaticLoader>();
     let p = JsonLdParser::new_with_options(options);
     let got: TestDataset = p
         .parse_str(r#"{"@id": "tag:foo", "tag:bar": "BAZ"}"#)

--- a/jsonld/src/serializer.rs
+++ b/jsonld/src/serializer.rs
@@ -48,10 +48,7 @@ impl<W, L> JsonLdSerializer<W, L> {
     }
 
     /// Convert a quad stream into a Json object
-    fn convert_quads<QS>(
-        &mut self,
-        source: QS,
-    ) -> StreamResult<JsonValue<()>, QS::Error, JsonLdError>
+    fn convert_quads<QS>(&mut self, source: QS) -> StreamResult<JsonValue, QS::Error, JsonLdError>
     where
         QS: QuadSource,
     {
@@ -110,7 +107,7 @@ pub type Jsonifier<L = NoLoader> = JsonLdSerializer<JsonTarget, L>;
 /// [`new_jsonifier`]: struct.JsonLdSerializer.html#method.new_jsonifier
 /// [`new_jsonifier_with`]: struct.JsonLdSerializer.html#method.new_jsonifier_with
 #[derive(Clone, Debug)]
-pub struct JsonTarget(JsonValue<()>);
+pub struct JsonTarget(JsonValue);
 
 impl Jsonifier {
     /// Create a new serializer which targets a [`JsonValue`].
@@ -130,13 +127,13 @@ impl<L> Jsonifier<L> {
 
     /// Get a reference to the converted `JsonValue`
     #[inline]
-    pub const fn as_json(&self) -> &JsonValue<()> {
+    pub const fn as_json(&self) -> &JsonValue {
         &self.target.0
     }
 
     /// Extract the converted `JsonValue`
     #[inline]
-    pub fn to_json(&mut self) -> JsonValue<()> {
+    pub fn to_json(&mut self) -> JsonValue {
         let mut ret = JsonValue::Null;
         std::mem::swap(&mut self.target.0, &mut ret);
         ret

--- a/jsonld/src/serializer/engine.rs
+++ b/jsonld/src/serializer/engine.rs
@@ -8,7 +8,6 @@ use crate::options::{
 use crate::util_traits::{HashMapUtil, QuadJsonLdUtil, TermJsonLdUtil, VecUtil};
 use json_syntax::object::Object;
 use json_syntax::{Parse, Value as JsonValue};
-use locspan::Meta;
 use sophia_api::ns::rdf;
 use sophia_api::quad::Quad;
 use sophia_api::source::{QuadSource, SinkError, StreamResult};
@@ -135,7 +134,7 @@ impl<'a, L> Engine<'a, L> {
     }
 
     /// Get the result as a `JsonValue`.
-    pub fn into_json(mut self) -> Result<JsonValue<()>, JsonLdError> {
+    pub fn into_json(mut self) -> Result<JsonValue, JsonLdError> {
         // check all list_seeds to mark them, if appropriate, as list nodes,
         // and also recursively mark other list nodes (traversing back rdf:rest links)
         let list_seeds = std::mem::take(&mut self.list_seeds);
@@ -193,7 +192,7 @@ impl<'a, L> Engine<'a, L> {
         inode: usize,
         node: &HashMap<Box<str>, Vec<RdfObject>>,
         root: bool,
-    ) -> Result<Option<Meta<JsonValue<()>, ()>>, JsonLdError> {
+    ) -> Result<Option<JsonValue>, JsonLdError> {
         //println!("=== jsonify {}", inode);
         if node.is_empty() {
             //println!("=== skipped because empty");
@@ -234,15 +233,14 @@ impl<'a, L> Engine<'a, L> {
                     .into(),
             );
         }
-        let obj = JsonValue::from(obj);
-        Ok(Some(obj.into()))
+        Ok(Some(JsonValue::from(obj)))
     }
 
     fn make_node_object(
         &self,
         id: &str,
         node: &HashMap<Box<str>, Vec<RdfObject>>,
-    ) -> Result<Object<()>, JsonLdError> {
+    ) -> Result<Object, JsonLdError> {
         let mut obj = Object::new();
         push_entry(&mut obj, "@id", id.into());
         for (key, vals) in node {
@@ -253,7 +251,7 @@ impl<'a, L> Engine<'a, L> {
                 let vals = vals
                     .iter()
                     .filter_map(|o| match o {
-                        RdfObject::Node(_, nid) => Some(Meta::from(JsonValue::from(nid.as_ref()))),
+                        RdfObject::Node(_, nid) => Some(JsonValue::from(nid.as_ref())),
                         _ => unreachable!(),
                     })
                     .collect::<Vec<_>>();
@@ -270,7 +268,7 @@ impl<'a, L> Engine<'a, L> {
         Ok(obj)
     }
 
-    fn convert_rdf_object(&self, val: &RdfObject) -> Result<Meta<JsonValue<()>, ()>, JsonLdError> {
+    fn convert_rdf_object(&self, val: &RdfObject) -> Result<JsonValue, JsonLdError> {
         let ret = match val {
             RdfObject::LangString(lex, tag) => {
                 let value = JsonValue::from(lex.as_ref());
@@ -320,13 +318,9 @@ impl<'a, L> Engine<'a, L> {
                     }
                 }
                 if dt_str == RDF_JSON {
-                    let _json_value = JsonValue::parse_str(txt, |span| span)?;
-                    // TODO Ideally, we should be able to strip the metadata like that:
-                    //let json_value = json_value.map_metadata_recursively(|_| ());
-                    // but because of a bug <https://github.com/timothee-haudebourg/json-syntax/issues/3>
-                    // we must instead parse the value again, without trackingh location
-                    let json_value = JsonValue::parse_str(txt, |_| ()).unwrap();
-                    push_entry(&mut obj, "@value", json_value.0);
+                    let (json_value, _) =
+                        JsonValue::parse_str(txt).map_err(JsonLdError::InvalidJsonLiteral)?;
+                    push_entry(&mut obj, "@value", json_value);
                     push_entry(&mut obj, "@type", "@json".into());
                 }
                 if obj.is_empty() {
@@ -336,8 +330,7 @@ impl<'a, L> Engine<'a, L> {
                         push_entry(&mut obj, "@type", dt_str.into());
                     }
                 }
-                let obj = JsonValue::from(obj);
-                obj.into()
+                JsonValue::from(obj)
             }
             RdfObject::Node(inode, id) => {
                 if id.as_ref() == RDF_NIL {
@@ -359,7 +352,7 @@ impl<'a, L> Engine<'a, L> {
                     && self.compound_literals.contains(inode)
                 {
                     let node = &self.node[*inode];
-                    let mut obj: Meta<JsonValue<()>, ()> = json_syntax::json!({
+                    let mut obj = json_syntax::json!({
                         "@value": JsonValue::from(node[RDF_VALUE][0].as_str()),
                         "@direction": JsonValue::from(node[RDF_DIRECTION][0].as_str()),
                     });
@@ -381,7 +374,7 @@ impl<'a, L> Engine<'a, L> {
 
     fn populate_list(
         &self,
-        list_items: &mut Vec<Meta<JsonValue<()>, ()>>,
+        list_items: &mut Vec<JsonValue>,
         inode: usize,
     ) -> Result<(), JsonLdError> {
         //println!("=== populate_list {}", gs_id);
@@ -442,6 +435,6 @@ const XSD_DOUBLE: &str = "http://www.w3.org/2001/XMLSchema#double";
 const XSD_INTEGER: &str = "http://www.w3.org/2001/XMLSchema#integer";
 const XSD_STRING: &str = "http://www.w3.org/2001/XMLSchema#string";
 
-fn push_entry(obj: &mut Object<()>, key: &str, value: JsonValue<()>) -> bool {
-    obj.push(Meta::new(key.into(), ()), value.into())
+fn push_entry(obj: &mut Object, key: &str, value: JsonValue) -> bool {
+    obj.push(key.into(), value)
 }

--- a/jsonld/src/serializer/test.rs
+++ b/jsonld/src/serializer/test.rs
@@ -36,9 +36,8 @@ fn iri_triple() -> TestResult {
                 ]
             }
         ]"#,
-        |_span| (),
     )?
-    .into_value();
+    .0;
     assert_eq!(got, exp, "{}", got.pretty_print());
     Ok(())
 }
@@ -72,9 +71,8 @@ fn mixed_triple() -> TestResult {
                 ]
             }
         ]"#,
-        |_span| (),
     )?
-    .into_value();
+    .0;
     assert_eq!(got, exp, "{}", got.pretty_print());
     Ok(())
 }
@@ -106,9 +104,8 @@ fn native_value() -> TestResult {
                 ]
             }
         ]"#,
-        |_span| (),
     )?
-    .into_value();
+    .0;
     assert_eq!(got, exp, "{}", got.pretty_print());
     Ok(())
 }

--- a/jsonld/src/vocabulary.rs
+++ b/jsonld/src/vocabulary.rs
@@ -1,36 +1,36 @@
 //! A Sophia-friendly implementation of [`rdf_types::Vocabulary`]
 use std::sync::Arc;
 
-use rdf_types::{
-    BlankIdVocabulary, BlankIdVocabularyMut, IriVocabulary, IriVocabularyMut,
-    LanguageTagVocabulary, LanguageTagVocabularyMut, LiteralVocabulary, LiteralVocabularyMut,
+use rdf_types::vocabulary::{
+    BlankIdVocabulary, BlankIdVocabularyMut, IriVocabulary, IriVocabularyMut, LiteralVocabulary,
+    LiteralVocabularyMut,
 };
 use sophia_api::{
     MownStr,
     term::{BnodeId, Term, TermKind},
 };
 
+use sophia_iri::Iri as SophiaIri;
+
 /// Self-explanatory IRI index for JSON-LD processing.
-pub type ArcIri = sophia_iri::Iri<Arc<str>>;
-/// Self-explanatory language tag index for JSON-LD processing.
-pub type ArcTag = sophia_api::term::LanguageTag<Arc<str>>;
+pub type ArcIri = SophiaIri<Arc<str>>;
 
 /// A [`Vocabulary`](rdf_types::Vocabulary) using `Arc<str>`-based types as index.
 ///
-/// These types match the notion of index in [`rdf_types`] as they are relatively cheap to clone,
-/// but offer the advantage of being self-explanatory, and resolvable to actual terms without actually needing the vocabulary.
+/// These types allow efficient conversion to/from sophia_iri and rdf-types types.
 #[derive(Clone, Debug, Default)]
 pub struct ArcVoc {}
 
 impl IriVocabulary for ArcVoc {
     type Iri = ArcIri;
 
-    fn iri<'i>(&'i self, id: &'i Self::Iri) -> Option<iref::Iri<'i>> {
-        Some(iref::Iri::new(id.as_str()).unwrap())
+    fn iri<'i>(&'i self, id: &'i Self::Iri) -> Option<&'i iref::Iri> {
+        // SAFETY: ArcIri is always a valid IRI
+        Some(unsafe { iref::Iri::new_unchecked(id.as_str()) })
     }
 
-    fn get(&self, iri: iref::Iri) -> Option<Self::Iri> {
-        Some(ArcIri::new_unchecked(Arc::from(iri.as_str())))
+    fn get(&self, iri: &iref::Iri) -> Option<Self::Iri> {
+        Some(SophiaIri::new_unchecked(Arc::from(iri.as_str())))
     }
 }
 
@@ -49,43 +49,27 @@ impl BlankIdVocabulary for ArcVoc {
 }
 
 impl LiteralVocabulary for ArcVoc {
-    type Literal = rdf_types::Literal<Self::Type, Self::Value>;
+    type Literal = rdf_types::Literal<ArcIri>;
 
-    type Type = rdf_types::literal::Type<ArcIri, ArcTag>;
-
-    type Value = String;
-    // I would rather use Arc<str>, but ToRdf::cloned_quads require that Value=String
-
-    fn literal<'l>(
-        &'l self,
-        id: &'l Self::Literal,
-    ) -> Option<&'l rdf_types::Literal<Self::Type, Self::Value>> {
-        Some(id)
+    fn literal<'l>(&'l self, id: &'l Self::Literal) -> Option<rdf_types::LiteralRef<'l, ArcIri>> {
+        Some(id.as_ref())
     }
 
-    fn get_literal(
+    fn get_literal(&self, id: rdf_types::LiteralRef<'_, ArcIri>) -> Option<Self::Literal> {
+        Some(id.into_owned())
+    }
+
+    fn owned_literal(
         &self,
-        id: &rdf_types::Literal<Self::Type, Self::Value>,
-    ) -> Option<Self::Literal> {
-        Some(id.to_owned())
-    }
-}
-
-impl LanguageTagVocabulary for ArcVoc {
-    type LanguageTag = ArcTag;
-
-    fn language_tag<'l>(&'l self, id: &'l Self::LanguageTag) -> Option<langtag::LanguageTag<'l>> {
-        Some(langtag::LanguageTag::parse(id.as_str()).unwrap())
-    }
-
-    fn get_language_tag(&self, id: langtag::LanguageTag) -> Option<Self::LanguageTag> {
-        Some(ArcTag::new_unchecked(Arc::from(id.as_str())))
+        id: Self::Literal,
+    ) -> Result<rdf_types::Literal<Self::Iri>, Self::Literal> {
+        Ok(id)
     }
 }
 
 impl IriVocabularyMut for ArcVoc {
-    fn insert(&mut self, iri: iref::Iri) -> Self::Iri {
-        self.get(iri).unwrap()
+    fn insert(&mut self, iri: &iref::Iri) -> Self::Iri {
+        SophiaIri::new_unchecked(Arc::from(iri.as_str()))
     }
 }
 
@@ -96,17 +80,8 @@ impl BlankIdVocabularyMut for ArcVoc {
 }
 
 impl LiteralVocabularyMut for ArcVoc {
-    fn insert_literal(
-        &mut self,
-        value: &rdf_types::Literal<Self::Type, Self::Value>,
-    ) -> Self::Literal {
+    fn insert_literal(&mut self, value: rdf_types::LiteralRef<'_, ArcIri>) -> Self::Literal {
         self.get_literal(value).unwrap()
-    }
-}
-
-impl LanguageTagVocabularyMut for ArcVoc {
-    fn insert_language_tag(&mut self, value: langtag::LanguageTag) -> Self::LanguageTag {
-        self.get_language_tag(value).unwrap()
     }
 }
 

--- a/resource/src/loader/_trait.rs
+++ b/resource/src/loader/_trait.rs
@@ -57,9 +57,9 @@ pub trait Loader: Sync + Sized {
                     .with_base(iri.as_ref().map_unchecked(Into::into))
                     .with_document_loader_factory(ClosureLoaderFactory::new(|| {
                         ClosureLoader::new(|url| {
+                            let result = self.get(url).map_err(|e| e.to_string());
                             async move {
-                                let (content, ctype) =
-                                    self.get(url.as_ref()).map_err(|e| e.to_string())?;
+                                let (content, ctype) = result?;
                                 if ctype == "application/ld+json" {
                                     String::from_utf8(content).map_err(|e| e.to_string())
                                 } else {

--- a/sophia/examples/jsonld-context.rs
+++ b/sophia/examples/jsonld-context.rs
@@ -26,7 +26,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let json_str = std::fs::read_to_string(&json_ld_path)
         .unwrap_or_else(|e| panic!("Could not read file {json_ld_path}: {e}"));
 
-    let mut options = JsonLdOptions::new().with_expansion_policy(Policy::Standard);
+    let mut options = JsonLdOptions::new().with_expansion_policy(Policy::default());
     if let Some(context_path) = context_path {
         let context_str = std::fs::read_to_string(&context_path)
             .map_err(|e| format!("Could not read file {}: {}", &context_path, e))?;


### PR DESCRIPTION
this PR upgrades the dependency [`json-ld`](https://crates.io/crates/json-ld) to the latest version (to date).

I'm reluctant to merge it at this point, because it breaks the ability to compile to WASM :-(
I tracked it down to the following issue: https://github.com/TrueLayer/reqwest-middleware/issues/276
where [`reqwest-middleware`](https://crates.io/crates/reqwest-middleware) is a dependency of [`json-ld-core`](https://crates.io/crates/json-ld-core).

I am willing to wait until this there is a way to compile to WASM, i.e. either
* this issue is solved https://github.com/TrueLayer/reqwest-middleware/issues/276
* this PR is merged and released https://github.com/timothee-haudebourg/json-ld/pull/91